### PR TITLE
添加NutParameterizedType,实现直接生成泛型的List/Map

### DIFF
--- a/src/org/nutz/lang/util/NutParameterizedType.java
+++ b/src/org/nutz/lang/util/NutParameterizedType.java
@@ -1,0 +1,56 @@
+package org.nutz.lang.util;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+
+public class NutParameterizedType implements ParameterizedType {
+	
+	public static Type list(Type clazz){
+		NutParameterizedType type = new NutParameterizedType();
+		type.rawType = List.class;
+		type.setActualTypeArguments(clazz);
+		return type;
+	}
+	
+	public static Type map(Type key, Type value){
+		NutParameterizedType type = new NutParameterizedType();
+		type.rawType = Map.class;
+		type.setActualTypeArguments(key,value);
+		return type;
+	}
+	
+	private Type[] actualTypeArguments;
+	
+	private Type rawType;
+	
+	private Type ownerType;
+
+	@Override
+	public Type[] getActualTypeArguments() {
+		return actualTypeArguments;
+	}
+
+	@Override
+	public Type getRawType() {
+		return rawType;
+	}
+
+	@Override
+	public Type getOwnerType() {
+		return ownerType;
+	}
+
+	public void setActualTypeArguments(Type...actualTypeArguments) {
+		this.actualTypeArguments = actualTypeArguments;
+	}
+	
+	public void setOwnerType(Type ownerType) {
+		this.ownerType = ownerType;
+	}
+	
+	public void setRawType(Type rawType) {
+		this.rawType = rawType;
+	}
+}

--- a/test/org/nutz/json/JsonTest.java
+++ b/test/org/nutz/json/JsonTest.java
@@ -26,6 +26,7 @@ import org.nutz.lang.Lang;
 import org.nutz.lang.Streams;
 import org.nutz.lang.stream.StringInputStream;
 import org.nutz.lang.stream.StringOutputStream;
+import org.nutz.lang.util.NutParameterizedType;
 
 @SuppressWarnings({"unchecked"})
 public class JsonTest {
@@ -649,4 +650,14 @@ public class JsonTest {
 		Map<String, Map<String, Object>> map = (Map<String, Map<String, Object>>) Json.fromJson(j);
 		assertNull(map.get("map").get("map"));
 	}
+	
+	@Test
+	public void test_from_list(){
+		List<Abc> list = (List<Abc>) Json.fromJson(NutParameterizedType.list(Abc.class), Streams.fileInr("org/nutz/json/list.txt"));
+		assertNotNull(list);
+		assertEquals(2, list.size());
+		assertEquals("nutz", list.get(0).name);
+		assertEquals("wendal", list.get(1).name);
+	}
 }
+

--- a/test/org/nutz/json/list.txt
+++ b/test/org/nutz/json/list.txt
@@ -1,0 +1,4 @@
+[
+	{"name":"nutz"},
+	{"name":"wendal"}
+]


### PR DESCRIPTION
添加NutParameterizedType,实现直接生成泛型的List/Map

使用方法:
List<Abc> list = (List<Abc>) Json.fromJson(NutParameterizedType.list(Abc.class), str);

Signed-off-by: Wendal Chen wendal1985@gmail.com
