### PR TITLE
给Strings类添加一个HTML元素转义的方法

### DIFF
--- a/src/org/nutz/lang/Strings.java
+++ b/src/org/nutz/lang/Strings.java
@@ -638,4 +638,34 @@ public abstract class Strings {
 		}
 		return sb.toString();
 	}
+
+	/**
+	 * 将一个字符串出现的HMTL元素进行转义，比如
+	 * 
+	 * <pre>
+	 *  escapeHtml("&lt;script&gt;alert("hello world");&lt;/script&gt;") => "&amp;lt;script&amp;gt;alert(&amp;quot;hello world&amp;quot;);&amp;lt;/script&amp;gt;"
+	 * </pre>
+	 * 
+	 * 转义字符对应如下
+	 * <ul>
+	 * <li>& => &amp;amp;
+	 * <li>< => &amp;lt;
+	 * <li>> => &amp;gt;
+	 * <li>' => &amp;#x27;
+	 * <li>" => &amp;quot;
+	 * </ul>
+	 * 
+	 * @param cs
+	 *            字符串
+	 * 
+	 * @return 转换后字符串
+	 */
+	public static String escapeHtml(CharSequence cs) {
+		return cs.toString()
+				.replaceAll("&", "&amp;")
+				.replaceAll("<", "&lt;")
+				.replaceAll(">", "&gt;")
+				.replaceAll("'", "&#x27;")
+				.replaceAll("\"", "&quot;");
+	}
 }

--- a/test/org/nutz/lang/StringsTest.java
+++ b/test/org/nutz/lang/StringsTest.java
@@ -290,4 +290,12 @@ public class StringsTest {
 		assertEquals("aBCD", Strings.upperWord("a-b-c-d", '-'));
 		assertEquals("helloWorld", Strings.upperWord("hello-world", '-'));
 	}
+	
+	@Test
+	public void test_escape_html() {
+		assertEquals("&lt;/article&gt;Oops &lt;script&gt;alert(&quot;hello world&quot;);&lt;/script&gt;",
+		             Strings.escapeHtml("</article>Oops <script>alert(\"hello world\");</script>"));
+		assertEquals("alert(&#x27;hello world&#x27;);",
+		             Strings.escapeHtml("alert('hello world');"));
+	}
 }


### PR DESCRIPTION
在jsp中使用el表达式的时候，如果一个pojo里面的某个元素从数据库里面取出来的值带有html标签的话，会造成页面出错的情况。
比如数据库某字段的值为「<script>alert("hello world");</script>」的话，直接用el输出则会出现个alert出来。
为了解决这个问题给Strings类里面添加了个转义方法
