### PR TITLE
增加 自定义SQL查询时,返回布尔型的值的回调的支持

### DIFF
--- a/src/org/nutz/dao/impl/sql/NutStatement.java
+++ b/src/org/nutz/dao/impl/sql/NutStatement.java
@@ -74,6 +74,10 @@ public abstract class NutStatement implements DaoStatement {
 		return getObject(String.class);
 	}
 
+	public boolean getBoolean() {
+		return getObject(Boolean.class);
+	}
+
 	public int getUpdateCount() {
 		return context.getUpdateCount();
 	}
@@ -120,11 +124,11 @@ public abstract class NutStatement implements DaoStatement {
 					sb.append(" |");
 				}
 			}
-			
+
 			if (maxRow != mtrx.length)
 				sb.append("\n  .............................................")
-				  .append("\n  !!!Too many data . Only display 50 lines , don't show the remaining record")
-				  .append("\n  .............................................");
+						.append("\n  !!!Too many data . Only display 50 lines , don't show the remaining record")
+						.append("\n  .............................................");
 			// 输出可执行的 SQL 语句, TODO 格式非常不好看!!如果要复制SQL,很麻烦!!!
 			sb.append("\n  For example:> \"");
 			sb.append(toStatement(mtrx, sql));

--- a/src/org/nutz/dao/impl/sql/callback/FetchBooleanCallback.java
+++ b/src/org/nutz/dao/impl/sql/callback/FetchBooleanCallback.java
@@ -1,0 +1,23 @@
+package org.nutz.dao.impl.sql.callback;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.nutz.dao.sql.Sql;
+import org.nutz.dao.sql.SqlCallback;
+
+/**
+ * 这个回调将返回一个 boolean 值
+ * 
+ * @author Conanca(conanca2006@gmail.com)
+ */
+public class FetchBooleanCallback implements SqlCallback {
+
+	public Object invoke(Connection conn, ResultSet rs, Sql sql) throws SQLException {
+		if (null != rs && rs.next())
+			return rs.getBoolean(1);
+		return null;
+	}
+
+}

--- a/src/org/nutz/dao/sql/DaoStatement.java
+++ b/src/org/nutz/dao/sql/DaoStatement.java
@@ -95,6 +95,11 @@ public interface DaoStatement {
 	String getString();
 
 	/**
+	 * @return 将结果对象作为 boolean 返回
+	 */
+	boolean getBoolean();
+
+	/**
 	 * 一个 getResult() 函数的变种，将当前对象的 Result 转换成 List<T> 返回。<br>
 	 * 如果 Result 本身就是一个列表，如果第一个元素的类型和参数相符，则直接返回，<br>
 	 * 否则会被用 Castors 智能转换 如果不是列表，则会强制用 ArrayList 包裹

--- a/test/org/nutz/dao/test/sqls/AllSqls.java
+++ b/test/org/nutz/dao/test/sqls/AllSqls.java
@@ -4,5 +4,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
-@Suite.SuiteClasses({SQLFileParsingTest.class, SqlImplTest.class, CustomizedSqlsTest.class})
-public class AllSqls {}
+@Suite.SuiteClasses({ SQLFileParsingTest.class, SqlImplTest.class, CustomizedSqlsTest.class, CallbackTest.class })
+public class AllSqls {
+}

--- a/test/org/nutz/dao/test/sqls/CallbackTest.java
+++ b/test/org/nutz/dao/test/sqls/CallbackTest.java
@@ -1,0 +1,31 @@
+package org.nutz.dao.test.sqls;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.nutz.dao.Sqls;
+import org.nutz.dao.impl.sql.callback.FetchBooleanCallback;
+import org.nutz.dao.sql.Sql;
+import org.nutz.dao.test.DaoCase;
+import org.nutz.dao.test.meta.Pet;
+
+public class CallbackTest extends DaoCase {
+
+	@Test
+	public void test_fetchBooleanCallback() {
+		pojos.initPet();
+		dao.insert(Pet.create(4));
+
+		Sql sql = Sqls.create("SELECT 'pet_02' IN (SELECT name FROM t_pet)");
+		sql.setCallback(new FetchBooleanCallback());
+		dao.execute(sql);
+		boolean pet02IsExsit = sql.getBoolean();
+		assertEquals(true, pet02IsExsit);
+
+		sql = Sqls.create("SELECT 'pet_05' IN (SELECT name FROM t_pet)");
+		sql.setCallback(new FetchBooleanCallback());
+		dao.execute(sql);
+		boolean pet05IsExsit = sql.getBoolean();
+		assertEquals(false, pet05IsExsit);
+	}
+}


### PR DESCRIPTION
既然支持获取字符串、整型、长整型等的回调，为何不添加个布尔型的回调呢？

用到形如“SELECT 'pet_02' IN (SELECT name FROM t_pet)”的自定义SQL，需获取其结果时就容易多了
