### PR TITLE
HttpResponse针对有压缩的情况的处理

### DIFF
--- a/src/org/nutz/http/Sender.java
+++ b/src/org/nutz/http/Sender.java
@@ -49,8 +49,26 @@ public abstract class Sender {
 		Response rep = null;
 		if (reHeaders != null && reHeaders.get(null) != null) {
 			rep = new Response(reHeaders);
-			if (rep.isOK())
-				rep.setStream(new BufferedInputStream(conn.getInputStream()));
+			if (rep.isOK()){
+				InputStream is1=conn.getInputStream();
+				InputStream is2=null;
+				String encoding=conn.getContentEncoding();
+				//如果采用了压缩,则需要处理否则都是乱码
+				if(encoding!=null && encoding.contains("gzip")){
+					 is2 = new GZIPInputStream (is1);
+	            		}
+				else if(encoding!=null && encoding.contains("deflate")){
+	            	 		 is2 = new InflaterInputStream (is1);
+	            		}
+	            		else
+	           		 {
+	            	 		is2 = is1;
+	            		}
+
+				BufferedInputStream is=new BufferedInputStream(is2);
+				rep.setStream(is);				
+			}
+				
 			else
 				rep.setStream(Lang.ins(""));
 		}


### PR DESCRIPTION
如果采用了压缩,则需要解压缩，否则获得的内容都是乱码
