### PR TITLE
修改当url包括"jar!"时扫描jar包出现的错误

### DIFF
--- a/src/org/nutz/resource/Scans.java
+++ b/src/org/nutz/resource/Scans.java
@@ -92,12 +92,12 @@ public class Scans {
 		try {
 			String str = url.toString();
 			if (str.endsWith(".jar")) {
-				return ResourceLocation.jar(url.toString());
+				return ResourceLocation.jar(str);
 			} 
 			else if (str.contains("jar!")) {
-				return ResourceLocation.jar(str.substring(0, str.lastIndexOf("jar!")) + 3);
+				return ResourceLocation.jar(str.substring(0, str.lastIndexOf("jar!") + 3));
 			}
-			else if (url.toString().startsWith("file:")) {
+			else if (str.startsWith("file:")) {
 				return ResourceLocation.file(new File(url.getFile()));
 			}
 			else {


### PR DESCRIPTION
上次修改`Scans`类时出现的一个bug，当是`jar!`的url时扫描不到资源
