### PR TITLE
fix for Mapl.excludeFilter()

### DIFF
--- a/src/org/nutz/mapl/impl/convert/FilterConvertImpl.java
+++ b/src/org/nutz/mapl/impl/convert/FilterConvertImpl.java
@@ -56,10 +56,15 @@ public class FilterConvertImpl extends MaplEach implements MaplConvert{
         if(clude){
            return;
         }
+        boolean inFilter = false;
         for(String p : paths){
-            if(!p.startsWith(path) && !path.startsWith(p)){
-                build.put(path, item, arrayIndex);
+            if(path.startsWith(p)){
+                inFilter = true;
+                break;
             }
+        }
+        if(!inFilter){
+        	build.put(path, item, arrayIndex);
         }
     }
 

--- a/test/org/nutz/mapl/MaplTest.java
+++ b/test/org/nutz/mapl/MaplTest.java
@@ -107,6 +107,38 @@ public class MaplTest {
     }
     
     /**
+     * 排除过滤测试，过滤多个项的内容
+     */
+    @Test
+    public void excludeFilterConvertTest_MultiplePath1(){
+        List<String> paths = new ArrayList<String>();
+        paths.add("users[].name");
+        paths.add("people[].age");
+        Object dest = Json.fromJson(Streams.fileInr("org/nutz/json/mateList.txt"));
+        Object obj = Mapl.excludeFilter(dest, paths);
+        assertNotNull(Mapl.cell(obj, "users"));
+        assertEquals(12, Mapl.cell(obj, "users[0].age"));
+        assertEquals("1", Mapl.cell(obj, "people[0].name"));
+    }
+    
+    /**
+     * 排除过滤测试，过滤多个项的内容。这是来自手册上的例子
+     */
+    @Test
+    public void excludeFilterConvertTest_MultiplePath2(){
+        String json = "{name:'nutz', age:12, address:[{area:1,name:'abc'},{area:2,name:'123'}]}";
+        Object obj = Json.fromJson(json);
+        List<String> list = new ArrayList<String>();
+        list.add("age");
+        list.add("address[].area");
+        Object newobj = Mapl.excludeFilter(obj, list);
+        assertNull(Mapl.cell(newobj, "age"));
+        assertEquals("nutz", Mapl.cell(newobj, "name"));
+        assertNull(Mapl.cell(newobj, "address[0].area"));
+        assertEquals("abc", Mapl.cell(newobj, "address[0].name"));
+    }
+    
+    /**
      * 对象转MapList测试
      */
     @Test


### PR DESCRIPTION
见 Issue #322
现存在于 1.b.45 中的算法无法实现多个 path 的排除过滤。
