### PR TITLE
SqlExpressionGroup增加了andInByParamsSql方法，使用PreparedStatement的执行方式

### DIFF
--- a/src/org/nutz/dao/util/cri/Exps.java
+++ b/src/org/nutz/dao/util/cri/Exps.java
@@ -65,6 +65,10 @@ public abstract class Exps {
     public static SqlRange inSql(String name, String subSql, Object... args) {
         return new SqlRange(name, subSql, args);
     }
+    
+    public static ParamsSqlRange inParamsSql(String name, String subSql, Object... args) {
+        return new ParamsSqlRange(name, subSql, args);
+    }
 
     public static SqlExpression create(String name, String op, Object value) {
         op = Strings.trim(op.toUpperCase());

--- a/src/org/nutz/dao/util/cri/ParamsSqlExpression.java
+++ b/src/org/nutz/dao/util/cri/ParamsSqlExpression.java
@@ -1,0 +1,62 @@
+/**
+ * 
+ */
+package org.nutz.dao.util.cri;
+
+import org.nutz.dao.entity.Entity;
+import org.nutz.dao.jdbc.Jdbcs;
+import org.nutz.dao.jdbc.ValueAdaptor;
+import org.nutz.lang.Mirror;
+
+/**
+ * @author mei
+ *
+ */
+public abstract class ParamsSqlExpression extends AbstractSqlExpression {
+	protected String sql;
+	protected Object[] args;
+	/**
+	 * @param name
+	 */
+	protected ParamsSqlExpression(String name, String sql, Object... args) {
+		super(name);
+		this.not = false;
+		this.sql = sql;
+		this.args = args;
+	}
+
+	@Override
+	public void joinSql(Entity<?> en, StringBuilder sb) {
+		sb.append(sql);
+	}
+
+	@Override
+	public int joinAdaptor(Entity<?> en, ValueAdaptor[] adaptors, int off) {
+		for (int i = 0; i < args.length; i++){
+			// 自动寻找适配器设置
+            if (null != args[i]) {
+                ValueAdaptor vab = Jdbcs.getAdaptor(Mirror.me(args[i]));
+                adaptors[off++] = vab;
+            }
+            // null 用 Null 适配器
+            else {
+            	adaptors[off++] = Jdbcs.Adaptor.asNull;
+            }
+		}
+        return off;
+	}
+
+	@Override
+	public int joinParams(Entity<?> en, Object obj, Object[] params, int off) {
+		for (Object arg : args)
+            params[off++] = arg;
+        return off;
+	}
+
+
+	@Override
+	public int paramCount(Entity<?> en) {
+		 return args.length;
+	}
+	
+}

--- a/src/org/nutz/dao/util/cri/ParamsSqlRange.java
+++ b/src/org/nutz/dao/util/cri/ParamsSqlRange.java
@@ -1,0 +1,34 @@
+/**
+ * 
+ */
+package org.nutz.dao.util.cri;
+
+import org.nutz.dao.entity.Entity;
+
+/**
+ * @author mei
+ *
+ */
+public class ParamsSqlRange extends ParamsSqlExpression{
+
+	/**
+	 * @param name
+	 */
+	protected ParamsSqlRange(String name, String sql, Object... args) {
+		super(name, sql, args);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.nutz.dao.sql.PItem#joinSql(org.nutz.dao.entity.Entity, java.lang.StringBuilder)
+	 */
+	@Override
+	public void joinSql(Entity<?> en, StringBuilder sb) {
+        sb.append(_fmtcol(en));
+        if (not)
+            sb.append(" NOT");
+        sb.append(" IN (");
+        sb.append(sql);
+        sb.append(")");
+	}
+
+}

--- a/src/org/nutz/dao/util/cri/SqlExpressionGroup.java
+++ b/src/org/nutz/dao/util/cri/SqlExpressionGroup.java
@@ -7,6 +7,7 @@ import static org.nutz.dao.util.cri.Exps.inInt;
 import static org.nutz.dao.util.cri.Exps.inLong;
 import static org.nutz.dao.util.cri.Exps.inStr;
 import static org.nutz.dao.util.cri.Exps.inSql;
+import static org.nutz.dao.util.cri.Exps.inParamsSql;
 import static org.nutz.dao.util.cri.Exps.isNull;
 import static org.nutz.dao.util.cri.Exps.like;
 import static org.nutz.dao.util.cri.Exps.lt;
@@ -100,6 +101,14 @@ public class SqlExpressionGroup extends AbstractPItem implements SqlExpression {
     public SqlExpressionGroup andNotInBySql(String name, String subSql, Object... args) {
         return and(inSql(name, subSql, args).not());
     }
+    
+    public SqlExpressionGroup andInByParamsSql(String name, String subSql, Object... args) {
+        return and(inParamsSql(name, subSql, args));
+    }
+
+    public SqlExpressionGroup andNotInByParamsSql(String name, String subSql, Object... args) {
+        return and(inParamsSql(name, subSql, args).not());
+    }
 
     public SqlExpressionGroup andNotIn(String name, long... ids) {
         return and(inLong(name, ids).not());
@@ -190,6 +199,14 @@ public class SqlExpressionGroup extends AbstractPItem implements SqlExpression {
 
     public SqlExpressionGroup orNotInBySql(String name, String subSql, Object... args) {
         return or(inSql(name, subSql, args).not());
+    }
+    
+    public SqlExpressionGroup orInByParamsSql(String name, String subSql, Object... args) {
+        return or(inParamsSql(name, subSql, args));
+    }
+
+    public SqlExpressionGroup orNotInByParamsSql(String name, String subSql, Object... args) {
+        return or(inParamsSql(name, subSql, args).not());
     }
 
     public SqlExpressionGroup orNotIn(String name, long... ids) {

--- a/src/org/nutz/dao/util/cri/SqlRange.java
+++ b/src/org/nutz/dao/util/cri/SqlRange.java
@@ -15,5 +15,4 @@ public class SqlRange extends NoParamsSqlExpression implements SqlExpression {
     public void joinSql(Entity<?> en, StringBuilder sb) {
         sb.append(String.format("%s%s IN (%s)", (not ? " NOT " : ""), _fmtcol(en), sql));
     }
-
 }


### PR DESCRIPTION
前面提了一个需求https://github.com/nutzam/nutz/issues/340
希望SqlExpressionGroup的andInBySql能转化为PreparedStatement的执行方式。
之后自己尝试修改了一下，但没有修改原来的方法，而是增加了andInByParamsSql方法和一些相关类，使用andInByParamsSql方法可以转化为PreparedStatement的执行方式。
没有十分细致地考虑，只是简单修改测试了一下，可能不那么周全或不大符合原框架的想法。希望能指教，谢谢。