### PR TITLE
生成json串时，默认改为输出紧凑格式

### DIFF
--- a/src/org/nutz/json/Json.java
+++ b/src/org/nutz/json/Json.java
@@ -188,7 +188,7 @@ public class Json {
      * @param obj
      *            JAVA 对象
      * @param format
-     *            JSON 字符串格式化 , 若format, 则定义为JsonFormat.nice()
+     *            JSON 字符串格式化 , 若format为null, 则定义为JsonFormat.compact()
      */
     public static void toJson(Writer writer, Object obj, JsonFormat format) {
         try {


### PR DESCRIPTION
一般格式往往仅限于调试，而实际使用中紧凑格式更为常见。生产项目中生成json串时都需要重新设定一下输出格式，非常繁琐，因此建议修改默认格式。
