### PR TITLE
添加一个java字段与数据库字段的便捷对应方式的注解

### DIFF
--- a/src/org/nutz/dao/entity/Entity.java
+++ b/src/org/nutz/dao/entity/Entity.java
@@ -274,4 +274,13 @@ public interface Entity<T> {
      */
     String getColumnComent(String columnName);
 
+    /**
+     * @return 是否有Java字段与数据库字段的便捷对应方式
+     */
+    boolean hasSimpleColumn();
+
+    /**
+     * @return Java字段与数据库字段的便捷对应关系的字符
+     */
+    Character getSimpleColumn();
 }

--- a/src/org/nutz/dao/entity/annotation/SimpleColumn.java
+++ b/src/org/nutz/dao/entity/annotation/SimpleColumn.java
@@ -1,0 +1,41 @@
+package org.nutz.dao.entity.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 声明一个 Java 字段与数据库字段的便捷对应方式
+ * <p>
+ * 如果 Java 字段名与数据库字段名是按照某种规则来一一对应，<br>
+ * 比如 Java 字段命名方式为驼峰式大小写（ camelCase ），而数据库字段为蛇底式小写（ snake_case ），<br>
+ * 通过这个注解可以快速的设置对应关系:
+ * 
+ * <pre>
+ *  &#064;SimpleColumn
+ * </pre>
+ * 
+ * 该注解默认使用底线（ _ ）连结。<br>
+ * 如果数据库字段为连接号（ - ）或其他字符来连接的话，则把该字符当成参数传入。
+ * 
+ * <pre>
+ *  &#064;SimpleColumn(&#x27;-&#x27;)
+ * </pre>
+ * 
+ * <b style=color:red>需要说明的是：</b>
+ * <ul>
+ * <li>声明了 '@Column' 的话，则按照 '@Column' 注解的效果来对该 POJO 进行处理。
+ * <li>对于该注解来说，在 POJO 对象的属性的声明优先于在 POJO 上的声明。
+ * <li>该注解能用在声明了 '@Id' 和 '@Name' 的字段上。
+ * </ul>
+ * 
+ * @author ywjno(ywjno.dev@gmail.com)
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.FIELD})
+@Documented
+public @interface SimpleColumn {
+    char value() default '_';
+}

--- a/src/org/nutz/dao/impl/entity/NutEntity.java
+++ b/src/org/nutz/dao/impl/entity/NutEntity.java
@@ -155,6 +155,16 @@ public class NutEntity<T> implements Entity<T> {
      */
     private PkType pkType;
 
+    /**
+     * 是否有Java字段与数据库字段的便捷对应方式
+     */
+    private boolean hasSimpleColumn;
+
+    /**
+     * Java字段与数据库字段的便捷对应关系的字符
+     */
+    private Character simpleColumn;
+
     public NutEntity(Class<T> type) {
         this.type = type;
         this.mirror = Mirror.me(type);
@@ -470,5 +480,21 @@ public class NutEntity<T> implements Entity<T> {
 
     public String getColumnComent(String columnName) {
         return columnComments.get(columnName);
+    }
+
+    public void setHasSimpleColumn(boolean hasSimpleColumn) {
+        this.hasSimpleColumn = hasSimpleColumn;
+    }
+
+    public boolean hasSimpleColumn() {
+        return hasSimpleColumn;
+    }
+
+    public Character getSimpleColumn() {
+        return simpleColumn;
+    }
+
+    public void setSimpleColumn(Character simpleColumn) {
+        this.simpleColumn = simpleColumn;
     }
 }

--- a/src/org/nutz/dao/impl/entity/field/NutMappingField.java
+++ b/src/org/nutz/dao/impl/entity/field/NutMappingField.java
@@ -51,9 +51,15 @@ public class NutMappingField extends AbstractEntityField implements MappingField
 
 	private boolean update = true;
 
+	private boolean hasSimpleColumn;
+
+	private Character simpleColumn;
+
 	public NutMappingField(Entity<?> entity) {
 		super(entity);
 		casesensitive = true;
+		hasSimpleColumn = entity.hasSimpleColumn();
+		simpleColumn = entity.getSimpleColumn();
 	}
 
 	public ValueAdaptor getAdaptor() {
@@ -238,4 +244,19 @@ public class NutMappingField extends AbstractEntityField implements MappingField
 		this.update = update;
 	}
 
+	public void setHasSimpleColumn(boolean hasSimpleColumn) {
+		this.hasSimpleColumn = hasSimpleColumn;
+	}
+
+	public boolean hasSimpleColumn() {
+		return hasSimpleColumn;
+	}
+
+	public Character getSimpleColumn() {
+		return simpleColumn;
+	}
+
+	public void setSimpleColumn(Character simpleColumn) {
+		this.simpleColumn = simpleColumn;
+	}
 }

--- a/src/org/nutz/dao/impl/entity/info/MappingInfo.java
+++ b/src/org/nutz/dao/impl/entity/info/MappingInfo.java
@@ -10,6 +10,7 @@ import org.nutz.dao.entity.annotation.Next;
 import org.nutz.dao.entity.annotation.PK;
 import org.nutz.dao.entity.annotation.Prev;
 import org.nutz.dao.entity.annotation.Readonly;
+import org.nutz.dao.entity.annotation.SimpleColumn;
 import org.nutz.lang.Lang;
 import org.nutz.lang.Mirror;
 
@@ -34,6 +35,8 @@ public class MappingInfo extends FieldInfo {
     public Readonly annReadonly;
 
     public Comment columnComment;
+
+    public SimpleColumn simpleColumn;
 
     public Class<?> getFieldTypeClass() {
         return Lang.getTypeClass(fieldType);

--- a/src/org/nutz/dao/impl/entity/info/TableInfo.java
+++ b/src/org/nutz/dao/impl/entity/info/TableInfo.java
@@ -2,6 +2,7 @@ package org.nutz.dao.impl.entity.info;
 
 import org.nutz.dao.entity.annotation.Comment;
 import org.nutz.dao.entity.annotation.PK;
+import org.nutz.dao.entity.annotation.SimpleColumn;
 import org.nutz.dao.entity.annotation.Table;
 import org.nutz.dao.entity.annotation.TableIndexes;
 import org.nutz.dao.entity.annotation.TableMeta;
@@ -21,4 +22,5 @@ public class TableInfo {
 
     public Comment tableComment;
 
+    public SimpleColumn simpleColumn;
 }

--- a/src/org/nutz/dao/impl/entity/info/_Infos.java
+++ b/src/org/nutz/dao/impl/entity/info/_Infos.java
@@ -17,6 +17,7 @@ import org.nutz.dao.entity.annotation.One;
 import org.nutz.dao.entity.annotation.PK;
 import org.nutz.dao.entity.annotation.Prev;
 import org.nutz.dao.entity.annotation.Readonly;
+import org.nutz.dao.entity.annotation.SimpleColumn;
 import org.nutz.lang.Lang;
 import org.nutz.lang.Mirror;
 import org.nutz.lang.eject.EjectByField;
@@ -125,7 +126,8 @@ public class _Infos {
         info.annPrev = field.getAnnotation(Prev.class);
         info.annReadonly = field.getAnnotation(Readonly.class);
         info.columnComment = field.getAnnotation(Comment.class);
-        
+        info.simpleColumn = field.getAnnotation(SimpleColumn.class);
+
         //检查@Id和@Name的属性类型
         if (info.annId != null) {
             if (!Mirror.me(field.getType()).isIntLike())

--- a/test/org/nutz/dao/test/entity/EntityParsingTest.java
+++ b/test/org/nutz/dao/test/entity/EntityParsingTest.java
@@ -134,4 +134,13 @@ public class EntityParsingTest extends DaoCase {
         Entity<?> en = en(TO5.class);
         assertEquals("toid", en.getField("id").getColumnName());
     }
+
+    @Test
+    public void test_simple_column() {
+        Entity<?> en = en(TO7.class);
+        assertEquals("primary_key", en.getField("primaryKey").getColumnName());
+        assertEquals("foreign#key", en.getField("foreignKey").getColumnName());
+        assertEquals("simple_column", en.getField("simpleColumn").getColumnName());
+        assertEquals("has-simple-column-anno", en.getField("hasSimpleColumnAnno").getColumnName());
+    }
 }

--- a/test/org/nutz/dao/test/entity/TO7.java
+++ b/test/org/nutz/dao/test/entity/TO7.java
@@ -1,0 +1,52 @@
+package org.nutz.dao.test.entity;
+
+import org.nutz.dao.entity.annotation.Id;
+import org.nutz.dao.entity.annotation.Name;
+import org.nutz.dao.entity.annotation.SimpleColumn;
+
+@SimpleColumn
+public class TO7 {
+    @Id
+    private Integer primaryKey;
+
+    @Name
+    @SimpleColumn('#')
+    private String foreignKey;
+
+    private String simpleColumn;
+
+    @SimpleColumn('-')
+    private String hasSimpleColumnAnno;
+
+    public Integer getPrimaryKey() {
+        return primaryKey;
+    }
+
+    public void setPrimaryKey(Integer primaryKey) {
+        this.primaryKey = primaryKey;
+    }
+
+    public String getForeignKey() {
+        return foreignKey;
+    }
+
+    public void setForeignKey(String foreignKey) {
+        this.foreignKey = foreignKey;
+    }
+
+    public String getSimpleColumn() {
+        return simpleColumn;
+    }
+
+    public void setSimpleColumn(String simpleColumn) {
+        this.simpleColumn = simpleColumn;
+    }
+
+    public String getHasSimpleColumnAnno() {
+        return hasSimpleColumnAnno;
+    }
+
+    public void setHasSimpleColumnAnno(String hasSimpleColumnAnno) {
+        this.hasSimpleColumnAnno = hasSimpleColumnAnno;
+    }
+}


### PR DESCRIPTION
当POJO属性与数据库字段有某种简单的一一对应关系的时候，可以在POJO或者其属性中使用`@SimpleColumn`注解来方便的产生某种对应关系，不再需要每个字段都单独追加`@Column`注解了
