### PR TITLE
如果obj2obj转换依然失败，则采用Json做中介进行终极转换，实现Bean与Bean的对拷

### DIFF
--- a/src/org/nutz/castor/castor/Object2Object.java
+++ b/src/org/nutz/castor/castor/Object2Object.java
@@ -2,6 +2,7 @@ package org.nutz.castor.castor;
 
 import org.nutz.castor.Castor;
 import org.nutz.castor.FailToCastObjectException;
+import org.nutz.json.Json;
 import org.nutz.lang.Mirror;
 
 public class Object2Object extends Castor<Object, Object> {
@@ -9,7 +10,11 @@ public class Object2Object extends Castor<Object, Object> {
     @Override
     public Object cast(Object src, Class<?> toType, String... args)
             throws FailToCastObjectException {
-        return Mirror.me(toType).born(src);
+        try {
+            return Mirror.me(toType).born(src);
+        } catch (Exception e) {
+            return Json.fromJson(toType, Json.toJson(src));
+        }
     }
 
 }

--- a/test/org/nutz/castor/CastorTest.java
+++ b/test/org/nutz/castor/CastorTest.java
@@ -19,6 +19,8 @@ import junit.framework.Assert;
 import org.junit.Test;
 import org.nutz.NutzEnum;
 import org.nutz.castor.castor.DateTimeCastor;
+import org.nutz.dao.test.entity.TO0;
+import org.nutz.dao.test.entity.TO5;
 import org.nutz.lang.Lang;
 import org.nutz.lang.meta.Email;
 
@@ -388,9 +390,18 @@ public class CastorTest {
                      Castors.me().castToString(timestamp));
 
         Castors.me().setSetting(new DefaultCastorSetting());
-
     }
 
+    @Test
+    public void testObj2Obj() {
+        TO0 src = new TO0();
+        src.id = 100;
+        src.name = "test";
+        TO5 desc = Castors.me().castTo(src, TO5.class);
+        assertEquals(src.id, desc.getId());
+        assertEquals(src.name, desc.getName());
+    }
+    
     static class MyCastorSetting {
         public static void setup(DateTimeCastor<Timestamp, String> c) {
             c.setDateFormat(new SimpleDateFormat("yyyy/MM/dd"));


### PR DESCRIPTION
有了这个功能，基本上commons-beanutils就可以砍掉了
