### PR TITLE
让Json支持注入各种JsonRender

### DIFF
--- a/src/org/nutz/json/Json.java
+++ b/src/org/nutz/json/Json.java
@@ -148,6 +148,15 @@ public class Json {
     // =========================================================================
     // ============================Json.toJson==================================
     // =========================================================================
+    private static Class<? extends JsonRender> jsonRenderCls;
+
+    public static Class<? extends JsonRender> getJsonRenderCls() {
+        return jsonRenderCls;
+    }
+
+    public static void setJsonRenderCls(Class<? extends JsonRender> jsonRenderCls) {
+        jsonRenderCls = jsonRenderCls;
+    }
 
     /**
      * 将一个 JAVA 对象转换成 JSON 字符串
@@ -201,7 +210,16 @@ public class Json {
         try {
             if (format == null)
                 format = JsonFormat.nice();
-            new JsonRenderImpl(writer, format).render(obj);
+
+            Class<? extends JsonRender> jrCls = getJsonRenderCls();
+            if (jrCls == null)
+                jrCls = JsonRenderImpl.class;
+
+            JsonRender jr = Mirror.me(jrCls).born();
+            jr.setWriter(writer);
+            jr.setFormat(format);
+            jr.render(obj);
+
             writer.flush();
         }
         catch (IOException e) {

--- a/src/org/nutz/json/JsonRender.java
+++ b/src/org/nutz/json/JsonRender.java
@@ -1,6 +1,7 @@
 package org.nutz.json;
 
 import java.io.IOException;
+import java.io.Writer;
 
 /**
  * 对象-->String, 一般就是写入Writer中
@@ -10,4 +11,8 @@ import java.io.IOException;
 public interface JsonRender {
 
     void render(Object obj) throws IOException, JsonException;
+
+    void setWriter(Writer writer);
+
+    void setFormat(JsonFormat jsonFormat);
 }

--- a/src/org/nutz/json/impl/JsonRenderImpl.java
+++ b/src/org/nutz/json/impl/JsonRenderImpl.java
@@ -40,6 +40,22 @@ public class JsonRenderImpl implements JsonRender {
 
     private Set<Object> memo = new HashSet<Object>();
 
+    public JsonFormat getFormat() {
+        return format;
+    }
+
+    public void setFormat(JsonFormat format) {
+        this.format = format;
+    }
+
+    public Writer getWriter() {
+        return writer;
+    }
+
+    public void setWriter(Writer writer) {
+        this.writer = writer;
+    }
+
     public void render(Object obj) throws IOException {
         if (null == obj) {
             writer.write("null");
@@ -90,6 +106,8 @@ public class JsonRenderImpl implements JsonRender {
             }
         }
     }
+
+    public JsonRenderImpl() {}
 
     public JsonRenderImpl(Writer writer, JsonFormat format) {
         this.format = format;

--- a/src/org/nutz/mapl/impl/convert/JsonConvertImpl.java
+++ b/src/org/nutz/mapl/impl/convert/JsonConvertImpl.java
@@ -5,8 +5,10 @@ import java.io.Writer;
 
 import org.nutz.json.JsonException;
 import org.nutz.json.JsonFormat;
+import org.nutz.json.JsonRender;
 import org.nutz.json.impl.JsonRenderImpl;
 import org.nutz.lang.Lang;
+import org.nutz.lang.Mirror;
 import org.nutz.lang.stream.StringWriter;
 import org.nutz.mapl.MaplConvert;
 
@@ -15,8 +17,18 @@ import org.nutz.mapl.MaplConvert;
  * @author juqkai(juqkai@gmail.com)
  */
 public class JsonConvertImpl implements MaplConvert{
+    private static Class<? extends JsonRender> jsonRenderCls;
+
+    public static Class<? extends JsonRender> getJsonRenderCls() {
+        return jsonRenderCls;
+    }
+
+    public static void setJsonRenderCls(Class<? extends JsonRender> jsonRenderCls) {
+        jsonRenderCls = jsonRenderCls;
+    }
+
     private JsonFormat format = null;
-    
+
     public JsonConvertImpl() {
         format = new JsonFormat();
     }
@@ -28,11 +40,19 @@ public class JsonConvertImpl implements MaplConvert{
         StringBuilder sb = new StringBuilder();
         Writer writer = new StringWriter(sb);
         try {
-            new JsonRenderImpl(writer, format).render(obj);
+            Class<? extends JsonRender> jrCls = getJsonRenderCls();
+            if (jrCls == null)
+                jrCls = JsonRenderImpl.class;
+
+            JsonRender jr = Mirror.me(jrCls).born();
+            jr.setWriter(writer);
+            jr.setFormat(format);
+            jr.render(obj);
+
             writer.flush();
             return sb.toString();
         } catch (IOException e) {
             throw Lang.wrapThrow(e, JsonException.class);
         }
-    };
+    }
 }


### PR DESCRIPTION
目的：
让Json支持注入各种JsonRender。

理由：
jvm其余上其余语言也有maplist结构，例如scala；通常情况下，scala的maplist很容易与java的maplist相互转换，但nutz的JsonRenderImpl只支持转换Java的maplist。

改动：
Json由依赖具体的JsonRenderImpl实现改为依赖JsonRender接口。
因Json.toJson的逻辑而扩展了JsonRender接口，允许注入writer和format。
根据原有Json.toJson使用JsonRender对象的方式，注入的是JsonRender的Class，在栈内实例化对象并在运行后抛弃。
同理改了JsonConvertImpl对JsonRenderImpl的强依赖。

AllJson测试，98 passed、1 ignored。
