### PR TITLE
“对象转为对象数组”应该忽略String类型

### DIFF
--- a/src/org/nutz/castor/Castors.java
+++ b/src/org/nutz/castor/Castors.java
@@ -226,7 +226,7 @@ public class Castors {
             return (T) src;
 
         Class<?> componentType = toType.getComponentType();
-        if (null != componentType && componentType.isAssignableFrom(fromType)) {
+        if (null != componentType && fromType != String.class && componentType.isAssignableFrom(fromType)) {
             Object array = Array.newInstance(componentType, 1);
             Array.set(array, 0, src);
             return (T) array;

--- a/test/org/nutz/castor/CastorTest.java
+++ b/test/org/nutz/castor/CastorTest.java
@@ -13,6 +13,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.nutz.NutzEnum;
 import org.nutz.castor.castor.Datetime2String;
+import org.nutz.castor.castor.String2Array;
 import org.nutz.lang.Lang;
 import org.nutz.lang.Times;
 import org.nutz.lang.meta.Email;
@@ -49,6 +50,11 @@ public class CastorTest {
         assertTrue(c.canCast(int.class, int[].class));
         assertTrue(c.canCast(String.class, String[].class));
         assertTrue(c.canCast(Dummy.class, Dummy[].class));
+
+        Castor<String, Object> string2Array = new String2Array();
+
+        assertArrayEquals((String[])string2Array.cast("[\"a\",\"b\",\"c\",123,456]", String[].class),
+                          c.cast("[\"a\",\"b\",\"c\",123,456]", String.class, String[].class));
     }
 
     @Test


### PR DESCRIPTION
“对象转为对象数组”应该忽略String类型，否则String2Array这个castor永远无法进入了，会导致所有依赖这个castor的行为不正确。

如原本的“["a","b","c",123,456]”应该生成new String[] {"a","b","c","123","456"}，但现在错误的生成为new String[] {"[\"a\",\"b\",\"c\",123,456]"}。
新增了针对这个情况的测试。
