### PR TITLE
增加String2Enum对名、值不同的枚举的支持。

### DIFF
--- a/src/org/nutz/castor/castor/String2Enum.java
+++ b/src/org/nutz/castor/castor/String2Enum.java
@@ -9,7 +9,16 @@ public class String2Enum extends Castor<String, Enum> {
     @SuppressWarnings("unchecked")
     @Override
     public Enum cast(String src, Class<?> toType, String... args) throws FailToCastObjectException {
-        return Enum.valueOf((Class<Enum>) toType, src);
+        try {
+            return Enum.valueOf((Class<Enum>) toType, src);
+        }
+        catch (IllegalArgumentException e) {
+            for (Object c : toType.getEnumConstants()) {
+                if (c.toString().equals(src)) return (Enum) c;
+            }
+
+            throw e;
+        }
     }
 
 }

--- a/test/org/nutz/castor/AlipayNotifyType.java
+++ b/test/org/nutz/castor/AlipayNotifyType.java
@@ -1,0 +1,16 @@
+package org.nutz.castor;
+
+public enum AlipayNotifyType {
+    StatusSync("trade_status_sync");
+
+    private String state;
+
+    private AlipayNotifyType(String s) {
+        state = s;
+    }
+
+    @Override
+    public String toString() {
+        return state;
+    }
+}

--- a/test/org/nutz/castor/CastorTest.java
+++ b/test/org/nutz/castor/CastorTest.java
@@ -488,4 +488,9 @@ public class CastorTest {
     // Castors castors = Castors.create().setPaths(new ArrayList<Class<?>>(0));
     // castors.castTo(1, Long.class);
     // }
+    @Test
+    public void testString2Enum() {
+        Assert.assertEquals(AlipayNotifyType.StatusSync, Castors.create().castTo("StatusSync", AlipayNotifyType.class));
+        Assert.assertEquals(AlipayNotifyType.StatusSync, Castors.create().castTo("trade_status_sync", AlipayNotifyType.class));
+    }
 }


### PR DESCRIPTION
### 当前nutz的String2Enum不支持以下的枚举

```
public enum AlipayNotifyType {
    StatusSync("trade_status_sync");

    private String state;

    private AlipayNotifyType(String s) {
        state = s;
    }

    @Override
    public String toString() {
        return state;
    }
}
```