### PR TITLE
改造dao.fetchLinks,使用普通的query方法实现查询,使其缓存友好

### DIFF
--- a/src/org/nutz/dao/impl/NutDao.java
+++ b/src/org/nutz/dao/impl/NutDao.java
@@ -27,7 +27,6 @@ import org.nutz.dao.impl.link.DoClearLinkVisitor;
 import org.nutz.dao.impl.link.DoClearRelationByHostFieldLinkVisitor;
 import org.nutz.dao.impl.link.DoClearRelationByLinkedFieldLinkVisitor;
 import org.nutz.dao.impl.link.DoDeleteLinkVisitor;
-import org.nutz.dao.impl.link.DoFetchLinkVisitor;
 import org.nutz.dao.impl.link.DoInsertLinkVisitor;
 import org.nutz.dao.impl.link.DoInsertRelationLinkVisitor;
 import org.nutz.dao.impl.link.DoUpdateLinkVisitor;
@@ -878,22 +877,6 @@ public class NutDao extends DaoSupport implements Dao {
                 lnk.setValue(obj, value);
             }
         }.opt(opt);
-    }
-    
-    protected Condition fitLinkCondition(Condition cndLink, Condition cnd) {
-        Condition CND = null;
-        Criteria _cnd = (Criteria)cndLink;
-        if (cnd != null && _cnd != null && cnd instanceof Criteria) {
-            Criteria cri = (Criteria)cnd;
-            cri.where().and(_cnd.where());
-            CND = cri;
-        } else {
-            if (cnd != null)
-                CND = cnd;
-            else
-                CND = _cnd;
-        }
-        return CND;
     }
 
     // ==========================================================

--- a/src/org/nutz/dao/impl/NutDao.java
+++ b/src/org/nutz/dao/impl/NutDao.java
@@ -858,14 +858,22 @@ public class NutDao extends DaoSupport implements Dao {
         return new DoClearLinkVisitor().opt(opt);
     }
 
-    private LinkVisitor doFetch(EntityOperator opt) {
-        return new DoFetchLinkVisitor().opt(opt);
-    }
-
     private LinkVisitor doLinkQuery(EntityOperator opt, final Condition cnd) {
         return new AbstractLinkVisitor() {
             public void visit(final Object obj, final LinkField lnk) {
-                Condition CND = fitLinkCondition(lnk.createCondition(obj), cnd);
+                Condition cndLink = lnk.createCondition(obj);
+                Condition CND = null;
+                Criteria _cnd = (Criteria) cndLink;
+                if (cnd != null && _cnd != null && cnd instanceof Criteria) {
+                    Criteria cri = (Criteria) cnd;
+                    cri.where().and(_cnd.where());
+                    CND = cri;
+                } else {
+                    if (cnd != null)
+                        CND = cnd;
+                    else
+                        CND = _cnd;
+                }
                 Object value = query(lnk.getLinkedEntity().getType(), CND);
                 lnk.setValue(obj, value);
             }

--- a/src/org/nutz/dao/impl/NutDao.java
+++ b/src/org/nutz/dao/impl/NutDao.java
@@ -32,7 +32,6 @@ import org.nutz.dao.impl.link.DoInsertLinkVisitor;
 import org.nutz.dao.impl.link.DoInsertRelationLinkVisitor;
 import org.nutz.dao.impl.link.DoUpdateLinkVisitor;
 import org.nutz.dao.impl.link.DoUpdateRelationLinkVisitor;
-import org.nutz.dao.impl.sql.pojo.ConditionPItem;
 import org.nutz.dao.impl.sql.pojo.PojoEachEntityCallback;
 import org.nutz.dao.impl.sql.pojo.PojoEachRecordCallback;
 import org.nutz.dao.impl.sql.pojo.PojoFetchEntityCallback;
@@ -46,13 +45,11 @@ import org.nutz.dao.jdbc.Jdbcs;
 import org.nutz.dao.pager.Pager;
 import org.nutz.dao.sql.Criteria;
 import org.nutz.dao.sql.DaoStatement;
-import org.nutz.dao.sql.PItem;
 import org.nutz.dao.sql.Pojo;
 import org.nutz.dao.sql.PojoCallback;
 import org.nutz.dao.sql.Sql;
 import org.nutz.dao.util.Daos;
 import org.nutz.dao.util.Pojos;
-import org.nutz.dao.util.cri.SqlExpressionGroup;
 import org.nutz.lang.ContinueLoop;
 import org.nutz.lang.Each;
 import org.nutz.lang.ExitLoop;
@@ -584,7 +581,7 @@ public class NutDao extends DaoSupport implements Dao {
                     return;
                 opt.entity.visitMany(ele, regex, doLinkQuery(opt, cnd));
                 opt.entity.visitManyMany(ele, regex, doLinkQuery(opt, cnd));
-                opt.entity.visitOne(ele, regex, doFetch(opt));
+                opt.entity.visitOne(ele, regex, doLinkQuery(opt, cnd));
                 opt.exec();
             }
         });
@@ -868,44 +865,27 @@ public class NutDao extends DaoSupport implements Dao {
     private LinkVisitor doLinkQuery(EntityOperator opt, final Condition cnd) {
         return new AbstractLinkVisitor() {
             public void visit(final Object obj, final LinkField lnk) {
-                Pojo pojo = opt.maker().makeQuery(lnk.getLinkedEntity());
-                pojo.setOperatingObject(obj);
-                PItem[] _cndItems = Pojos.Items.cnd(lnk.createCondition(obj));
-                pojo.append(_cndItems);
-                if (cnd != null) {
-                    if (cnd instanceof Criteria) {
-                        Criteria cri = (Criteria) cnd;
-                        SqlExpressionGroup seg = cri.where();
-                        if (_cndItems.length > 0
-                            && seg != null
-                            && !seg.isEmpty()) {
-                            seg.setTop(false);
-                            pojo.append(Pojos.Items.wrap(" AND "));
-                        }
-                        pojo.append(cri);
-                        if (cri.getPager() != null) {
-                            pojo.setPager(cri.getPager());
-                            expert.formatQuery(pojo);
-                        }
-                    }
-                    // 普通条件
-                    else {
-                        pojo.append(new ConditionPItem(cnd));
-                    }
-                }
-                pojo.setAfter(new PojoCallback() {
-                    public Object invoke(Connection conn,
-                                         ResultSet rs,
-                                         Pojo pojo) throws SQLException {
-                        Object value = lnk.getCallback().invoke(conn, rs, pojo);
-                        lnk.setValue(obj, value);
-                        return value;
-                    }
-                });
-                pojo.setEntity(lnk.getLinkedEntity());
-                opt.add(pojo);
+                Condition CND = fitLinkCondition(lnk.createCondition(obj), cnd);
+                Object value = query(lnk.getLinkedEntity().getType(), CND);
+                lnk.setValue(obj, value);
             }
         }.opt(opt);
+    }
+    
+    protected Condition fitLinkCondition(Condition cndLink, Condition cnd) {
+        Condition CND = null;
+        Criteria _cnd = (Criteria)cndLink;
+        if (cnd != null && _cnd != null && cnd instanceof Criteria) {
+            Criteria cri = (Criteria)cnd;
+            cri.where().and(_cnd.where());
+            CND = cri;
+        } else {
+            if (cnd != null)
+                CND = cnd;
+            else
+                CND = _cnd;
+        }
+        return CND;
     }
 
     // ==========================================================

--- a/src/org/nutz/dao/impl/NutDao.java
+++ b/src/org/nutz/dao/impl/NutDao.java
@@ -858,7 +858,7 @@ public class NutDao extends DaoSupport implements Dao {
     }
 
     private LinkVisitor doLinkQuery(EntityOperator opt, final Condition cnd) {
-        return new AbstractLinkVisitor() {
+        return new LinkVisitor() {
             public void visit(final Object obj, final LinkField lnk) {
                 Condition cndLink = lnk.createCondition(obj);
                 Condition CND = null;
@@ -876,7 +876,7 @@ public class NutDao extends DaoSupport implements Dao {
                 Object value = query(lnk.getLinkedEntity().getType(), CND);
                 lnk.setValue(obj, value);
             }
-        }.opt(opt);
+        };
     }
 
     // ==========================================================


### PR DESCRIPTION
原有的实现使用Pojo的after钩子来实现, 现在改成用Dao原有的query方法实现,这样就实现了缓存友好. 因为缓存是根据sql缓存