### PR TITLE
添加两个 Adaptor 类让更方便的使用 PostgreSQL 数据库

### DIFF
--- a/src/org/nutz/castor/castor/Map2String.java
+++ b/src/org/nutz/castor/castor/Map2String.java
@@ -5,13 +5,14 @@ import java.util.Map;
 import org.nutz.castor.Castor;
 import org.nutz.castor.FailToCastObjectException;
 import org.nutz.json.Json;
+import org.nutz.json.JsonFormat;
 
 @SuppressWarnings({"rawtypes"})
 public class Map2String extends Castor<Map, String> {
 
     @Override
     public String cast(Map src, Class<?> toType, String... args) throws FailToCastObjectException {
-        return Json.toJson(src);
+        return Json.toJson(src, JsonFormat.tidy());
     }
 
 }

--- a/src/org/nutz/castor/castor/Object2String.java
+++ b/src/org/nutz/castor/castor/Object2String.java
@@ -1,14 +1,24 @@
 package org.nutz.castor.castor;
 
+import java.lang.reflect.Method;
+
 import org.nutz.castor.Castor;
 import org.nutz.castor.FailToCastObjectException;
+import org.nutz.json.Json;
+import org.nutz.json.JsonFormat;
+import org.nutz.lang.Mirror;
 
 public class Object2String extends Castor<Object, String> {
 
     @Override
     public String cast(Object src, Class<?> toType, String... args)
             throws FailToCastObjectException {
-        return src.toString();
+        for (Method method : Mirror.me(src).getMethods()) {
+            if ("toString".equals(method.getName())) {
+                return src.toString();
+            }
+        }
+        return Json.toJson(src, JsonFormat.tidy());
     }
 
 }

--- a/src/org/nutz/dao/entity/annotation/ColType.java
+++ b/src/org/nutz/dao/entity/annotation/ColType.java
@@ -60,5 +60,10 @@ public enum ColType {
     /**
      * 浮点:根据字段的宽度和精度来决定具体的数据库字段类型
      */
-    FLOAT
+    FLOAT,
+    
+    /**
+     * 数组:PostgreSQL的数组类型
+     */
+    PSQL_ARRAY
 }

--- a/src/org/nutz/dao/impl/jdbc/psql/PsqlArrayAdaptor.java
+++ b/src/org/nutz/dao/impl/jdbc/psql/PsqlArrayAdaptor.java
@@ -8,6 +8,44 @@ import java.sql.Types;
 
 import org.nutz.dao.jdbc.ValueAdaptor;
 
+/**
+ * 为 PostgreSQL 数据库封装对数组类型的支持
+ * <p/>
+ * 注意，需要给 POJO 添加<b>带一个参数的静态工厂方法</b>或者<b>带一个参数的构造函数</b>，<br>
+ * 显示的使用 java.sql.ResultSet 来创建该 POJO，不然会出现无法映射的错误。
+ * <p/>
+ * <code>
+public class Pet {
+
+    public static Pet getInstance(ResultSet rs) throws SQLException {
+        Pet pet = new Pet();
+        pet.setId(rs.getInt("id"));
+        pet.setPayByQuarter((Integer[]) rs.getArray("pay_by_quarter").getArray());
+        return pet;
+    }
+
+    &#64;Column("pay_by_quarter")
+    &#64;ColDefine(customType = "integer[]", type = ColType.PSQL_ARRAY)
+    private Integer[] payByQuarter;
+
+    // ... 省略后面代码，包括字段声明以及 getter 和 setter
+}
+
+public class Jone {
+
+    public static Jone(ResultSet rs) throws SQLException {
+        this.id = rs.getInt("id");
+        this.schedule = (String[]) rs.getArray("schedule").getArray();
+    }
+
+    &#64;ColDefine(customType = "varchar[]", type = ColType.PSQL_ARRAY)
+    private String[] schedule;
+
+    // ... 省略后面代码，包括字段声明以及 getter 和 setter
+}
+</code>
+ * 
+ */
 public class PsqlArrayAdaptor implements ValueAdaptor {
 
     private String customDbType;

--- a/src/org/nutz/dao/impl/jdbc/psql/PsqlArrayAdaptor.java
+++ b/src/org/nutz/dao/impl/jdbc/psql/PsqlArrayAdaptor.java
@@ -1,0 +1,34 @@
+package org.nutz.dao.impl.jdbc.psql;
+
+import java.sql.Array;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+import org.nutz.dao.jdbc.ValueAdaptor;
+
+public class PsqlArrayAdaptor implements ValueAdaptor {
+
+    private String customDbType;
+
+    public PsqlArrayAdaptor(String customDbType) {
+        this.customDbType = customDbType;
+    }
+
+    @Override
+    public Object get(ResultSet rs, String colName) throws SQLException {
+        return rs.getObject(colName);
+    }
+
+    @Override
+    public void set(PreparedStatement stat, Object obj, int index) throws SQLException {
+        if (null == obj) {
+            stat.setNull(index, Types.NULL);
+        } else {
+            String typeName = customDbType.substring(0, customDbType.length() - 2);
+            Array array = stat.getConnection().createArrayOf(typeName, (Object[]) obj);
+            stat.setObject(index, array, Types.ARRAY);
+        }
+    }
+}

--- a/src/org/nutz/dao/impl/jdbc/psql/PsqlJdbcExpert.java
+++ b/src/org/nutz/dao/impl/jdbc/psql/PsqlJdbcExpert.java
@@ -9,6 +9,7 @@ import org.nutz.dao.Sqls;
 import org.nutz.dao.entity.Entity;
 import org.nutz.dao.entity.MappingField;
 import org.nutz.dao.entity.PkType;
+import org.nutz.dao.entity.annotation.ColType;
 import org.nutz.dao.impl.jdbc.AbstractJdbcExpert;
 import org.nutz.dao.impl.jdbc.BlobValueAdaptor2;
 import org.nutz.dao.jdbc.JdbcExpertConfigFile;
@@ -152,6 +153,8 @@ public class PsqlJdbcExpert extends AbstractJdbcExpert {
             return new BlobValueAdaptor2(Jdbcs.getFilePool());
         } else if ("JSON".equalsIgnoreCase(ef.getCustomDbType())) {
             return new PsqlJsonAdaptor();
+        } else if (ColType.PSQL_ARRAY == ef.getColumnType()) {
+            return new PsqlArrayAdaptor(ef.getCustomDbType());
         } else {
             return super.getAdaptor(ef);
         }

--- a/src/org/nutz/dao/impl/jdbc/psql/PsqlJdbcExpert.java
+++ b/src/org/nutz/dao/impl/jdbc/psql/PsqlJdbcExpert.java
@@ -34,17 +34,18 @@ public class PsqlJdbcExpert extends AbstractJdbcExpert {
         Pager pager = pojo.getContext().getPager();
         // 需要进行分页
         if (null != pager && pager.getPageNumber() > 0)
-            pojo.append(Pojos.Items.wrapf(    " LIMIT %d OFFSET %d",
-                                            pager.getPageSize(),
-                                            pager.getOffset()));
+            pojo.append(Pojos.Items.wrapf(" LIMIT %d OFFSET %d",
+                                          pager.getPageSize(),
+                                          pager.getOffset()));
     }
-    
+
     public void formatQuery(Sql sql) {
         Pager pager = sql.getContext().getPager();
         if (null != pager && pager.getPageNumber() > 0) {
-            sql.setSourceSql(sql.getSourceSql() + String.format(" LIMIT %d OFFSET %d",
-                                            pager.getPageSize(),
-                                            pager.getOffset()));
+            sql.setSourceSql(sql.getSourceSql()
+                             + String.format(" LIMIT %d OFFSET %d",
+                                             pager.getPageSize(),
+                                             pager.getOffset()));
         }
     }
 
@@ -82,7 +83,8 @@ public class PsqlJdbcExpert extends AbstractJdbcExpert {
         List<MappingField> pks = en.getPks();
         if (!pks.isEmpty()) {
             sb.append('\n');
-            sb.append(String.format("CONSTRAINT %s_pkey PRIMARY KEY (", en.getTableName().replace('.', '_').replace('"', '_')));
+            sb.append(String.format("CONSTRAINT %s_pkey PRIMARY KEY (",
+                                    en.getTableName().replace('.', '_').replace('"', '_')));
             for (MappingField pk : pks) {
                 sb.append(pk.getColumnName()).append(',');
             }
@@ -131,10 +133,10 @@ public class PsqlJdbcExpert extends AbstractJdbcExpert {
 
         case BINARY:
             return "BYTEA";
-            
+
         case DATETIME:
             return "TIMESTAMP";
-        default :
+        default:
             break;
         }
         return super.evalFieldType(mf);
@@ -146,8 +148,12 @@ public class PsqlJdbcExpert extends AbstractJdbcExpert {
 
     @Override
     public ValueAdaptor getAdaptor(MappingField ef) {
-        if (ef.getTypeMirror().isOf(Blob.class))
+        if (ef.getTypeMirror().isOf(Blob.class)) {
             return new BlobValueAdaptor2(Jdbcs.getFilePool());
-        return super.getAdaptor(ef);
+        } else if ("JSON".equalsIgnoreCase(ef.getCustomDbType())) {
+            return new PsqlJsonAdaptor();
+        } else {
+            return super.getAdaptor(ef);
+        }
     }
 }

--- a/src/org/nutz/dao/impl/jdbc/psql/PsqlJsonAdaptor.java
+++ b/src/org/nutz/dao/impl/jdbc/psql/PsqlJsonAdaptor.java
@@ -1,0 +1,27 @@
+package org.nutz.dao.impl.jdbc.psql;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+
+import org.nutz.dao.jdbc.ValueAdaptor;
+import org.nutz.json.Json;
+import org.nutz.json.JsonFormat;
+
+public class PsqlJsonAdaptor implements ValueAdaptor {
+
+    @Override
+    public Object get(ResultSet rs, String colName) throws SQLException {
+        return rs.getObject(colName);
+    }
+
+    @Override
+    public void set(PreparedStatement stat, Object obj, int index) throws SQLException {
+        if (null == obj) {
+            stat.setNull(index, Types.NULL);
+        } else {
+            stat.setObject(index, Json.toJson(obj, JsonFormat.tidy()), Types.OTHER);
+        }
+    }
+}

--- a/src/org/nutz/dao/impl/jdbc/psql/PsqlJsonAdaptor.java
+++ b/src/org/nutz/dao/impl/jdbc/psql/PsqlJsonAdaptor.java
@@ -9,6 +9,53 @@ import org.nutz.dao.jdbc.ValueAdaptor;
 import org.nutz.json.Json;
 import org.nutz.json.JsonFormat;
 
+/**
+ * 为 PostgreSQL 数据库封装对 Json 类型的支持
+ * <p/>
+ * 数据库里面的 Json 类型的值自动为 String 类型。
+ * <p/>
+ * 注意，必要的时候需要给 POJO 添加<b>带一个参数的静态工厂方法</b>或者<b>带一个参数的构造函数</b>，<br>
+ * 显示的使用 java.sql.ResultSet 来创建该 POJO，不然会出现无法映射的错误。
+ * <p/>
+ * <code>
+public class Pet {
+
+    public static Pet getInstance(ResultSet rs) throws SQLException {
+        // 需要把所有字段从 ResultSet 取出，不然该属性无法映射
+        Pet pet = new Pet();
+        pet.setId(rs.getInt("id"));
+        pet.setData(NutMap.WRAP(rs.getString("data")));
+        return pet;
+    }
+
+    &#64;Id
+    private int id;
+
+    &#64;ColDefine(customType = "json")
+    private NutMap data;
+
+    // ... 省略后面代码，包括字段声明以及 getter 和 setter
+}
+
+public class Jone {
+
+    public static Jone(ResultSet rs) throws SQLException {
+        // 需要把所有字段从 ResultSet 取出，不然该属性无法映射
+        this.id = rs.getInt("id");
+        this.info = Json.fromJson(Information.class, rs.getString("info"));
+    }
+
+    &#64;Id
+    private int id;
+
+    &#64;ColDefine(customType = "json")
+    private Information info;
+
+    // ... 省略后面代码，包括字段声明以及 getter 和 setter
+}
+</code>
+ * 
+ */
 public class PsqlJsonAdaptor implements ValueAdaptor {
 
     @Override

--- a/test/org/nutz/dao/AllDao.java
+++ b/test/org/nutz/dao/AllDao.java
@@ -8,6 +8,7 @@ import org.nutz.dao.test.entity.AllEntity;
 import org.nutz.dao.test.exec.AllDaoExec;
 import org.nutz.dao.test.mapping.*;
 import org.nutz.dao.test.normal.AllNormal;
+import org.nutz.dao.test.normal.psql.Psql;
 import org.nutz.dao.test.smoke.AllSmoke;
 import org.nutz.dao.test.sqls.AllSqls;
 import org.nutz.dao.texp.ChainTest;
@@ -22,13 +23,14 @@ import org.nutz.dao.texp.CndTest;
  */
 
 @RunWith(Suite.class)
-@Suite.SuiteClasses({    AllEntity.class,
-                        AllSmoke.class,
-                        AllSqls.class,
-                        AllMapping.class,
-                        AllNormal.class,
-                        CndTest.class,
-                        ChainTest.class,
-                        SqlLiteralTest.class,
-                        AllDaoExec.class})
+@Suite.SuiteClasses({AllEntity.class,
+                     AllSmoke.class,
+                     AllSqls.class,
+                     AllMapping.class,
+                     AllNormal.class,
+                     CndTest.class,
+                     ChainTest.class,
+                     SqlLiteralTest.class,
+                     AllDaoExec.class,
+                     Psql.class})
 public class AllDao {}

--- a/test/org/nutz/dao/test/normal/psql/Psql.java
+++ b/test/org/nutz/dao/test/normal/psql/Psql.java
@@ -1,0 +1,8 @@
+package org.nutz.dao.test.normal.psql;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({PsqlJsonTest.class, PsqlArrayTest.class})
+public class Psql {}

--- a/test/org/nutz/dao/test/normal/psql/PsqlArrayTest.java
+++ b/test/org/nutz/dao/test/normal/psql/PsqlArrayTest.java
@@ -1,0 +1,42 @@
+package org.nutz.dao.test.normal.psql;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.nutz.dao.test.DaoCase;
+import org.nutz.lang.Lang;
+
+public class PsqlArrayTest extends DaoCase {
+    @Override
+    protected void before() {
+        dao.create(StudentArray.class, true);
+    }
+
+    @Test
+    public void crud() {
+        StudentArray student = new StudentArray();
+        Integer[] payByQuarter = {1000, 1300, 1500, 1200};
+        String[] schedule = new String[]{"02", "05", "08", "11"};
+        student.setPayByQuarter(payByQuarter);
+        student.setSchedule(schedule);
+
+        int insertId = dao.insert(student).getId();
+        StudentArray insertStudent = dao.fetch(StudentArray.class, insertId);
+        assertTrue(Lang.equals(payByQuarter, insertStudent.getPayByQuarter()));
+        assertTrue(Lang.equals(schedule, insertStudent.getSchedule()));
+
+        payByQuarter[2] = 2500;
+        schedule[2] = "09";
+        insertStudent.setPayByQuarter(payByQuarter);
+        insertStudent.setSchedule(schedule);
+        dao.updateIgnoreNull(insertStudent);
+        StudentArray updateStudent = dao.fetch(StudentArray.class, insertId);
+        assertEquals(Integer.valueOf(2500), updateStudent.getPayByQuarter()[2]);
+        assertEquals("09", updateStudent.getSchedule()[2]);
+
+        dao.delete(StudentJson.class, insertId);
+        assertNull(dao.fetch(StudentJson.class, insertId));
+    }
+}

--- a/test/org/nutz/dao/test/normal/psql/PsqlJsonTest.java
+++ b/test/org/nutz/dao/test/normal/psql/PsqlJsonTest.java
@@ -1,0 +1,46 @@
+package org.nutz.dao.test.normal.psql;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.math.BigDecimal;
+
+import org.junit.Test;
+import org.nutz.dao.test.DaoCase;
+import org.nutz.lang.util.NutMap;
+
+public class PsqlJsonTest extends DaoCase {
+
+    @Override
+    protected void before() {
+        dao.create(StudentJson.class, true);
+    }
+
+    @Test
+    public void crud() {
+        NutMap data = NutMap.NEW().setv("name", "Alpha").setv("age", 20).setv("addr", "Beijing");
+        StudentResult alphaResult = new StudentResult();
+        alphaResult.setMathematics("A");
+        alphaResult.setPhysics(new BigDecimal("100"));
+        alphaResult.setForeignLanguage(120);
+        StudentJson student = new StudentJson();
+        student.setData(data);
+        student.setStudentResult(alphaResult);
+
+        int insertId = dao.insert(student).getId();
+        StudentJson insertStudent = dao.fetch(StudentJson.class, insertId);
+        assertEquals(data, insertStudent.getData());
+        assertTrue(alphaResult.equals(insertStudent.getStudentResult()));
+
+        insertStudent.getData().put("addr", "Dalian");
+        insertStudent.getStudentResult().setMathematics("S");
+        dao.updateIgnoreNull(insertStudent);
+        StudentJson updateStudent = dao.fetch(StudentJson.class, insertId);
+        assertEquals("Dalian", updateStudent.getData().get("addr"));
+        assertEquals("S", updateStudent.getStudentResult().getMathematics());
+
+        dao.delete(StudentJson.class, insertId);
+        assertNull(dao.fetch(StudentJson.class, insertId));
+    }
+}

--- a/test/org/nutz/dao/test/normal/psql/Student.java
+++ b/test/org/nutz/dao/test/normal/psql/Student.java
@@ -1,0 +1,19 @@
+package org.nutz.dao.test.normal.psql;
+
+import org.nutz.dao.entity.annotation.Id;
+import org.nutz.dao.entity.annotation.Table;
+
+@Table("t_psql_student")
+public class Student {
+
+    @Id
+    private int id;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+}

--- a/test/org/nutz/dao/test/normal/psql/StudentArray.java
+++ b/test/org/nutz/dao/test/normal/psql/StudentArray.java
@@ -1,0 +1,43 @@
+package org.nutz.dao.test.normal.psql;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.nutz.dao.entity.annotation.ColDefine;
+import org.nutz.dao.entity.annotation.ColType;
+import org.nutz.dao.entity.annotation.Column;
+
+public class StudentArray extends Student {
+
+    public StudentArray() {}
+
+    public StudentArray(ResultSet rs) throws SQLException {
+        this.setId(rs.getInt("id"));
+        this.payByQuarter = (Integer[]) rs.getArray("pay_by_quarter").getArray();
+        this.schedule = (String[]) rs.getArray("schedule").getArray();
+    }
+
+    @Column("pay_by_quarter")
+    @ColDefine(customType = "integer[]", type = ColType.PSQL_ARRAY)
+    private Integer[] payByQuarter;
+
+    @Column("schedule")
+    @ColDefine(customType = "varchar[]", type = ColType.PSQL_ARRAY)
+    private String[] schedule;
+
+    public Integer[] getPayByQuarter() {
+        return payByQuarter;
+    }
+
+    public void setPayByQuarter(Integer[] payByQuarter) {
+        this.payByQuarter = payByQuarter;
+    }
+
+    public String[] getSchedule() {
+        return schedule;
+    }
+
+    public void setSchedule(String[] schedule) {
+        this.schedule = schedule;
+    }
+}

--- a/test/org/nutz/dao/test/normal/psql/StudentJson.java
+++ b/test/org/nutz/dao/test/normal/psql/StudentJson.java
@@ -1,0 +1,41 @@
+package org.nutz.dao.test.normal.psql;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.nutz.dao.entity.annotation.ColDefine;
+import org.nutz.json.Json;
+import org.nutz.lang.util.NutMap;
+
+public class StudentJson extends Student {
+
+    public StudentJson() {}
+
+    public StudentJson(ResultSet rs) throws SQLException {
+        this.setId(rs.getInt("id"));
+        this.data = NutMap.WRAP(rs.getString("data"));
+        this.studentResult = Json.fromJson(StudentResult.class, rs.getString("studentResult"));
+    }
+
+    @ColDefine(customType = "json")
+    private NutMap data;
+
+    @ColDefine(customType = "json")
+    private StudentResult studentResult;
+
+    public NutMap getData() {
+        return data;
+    }
+
+    public void setData(NutMap data) {
+        this.data = data;
+    }
+
+    public StudentResult getStudentResult() {
+        return studentResult;
+    }
+
+    public void setStudentResult(StudentResult studentResult) {
+        this.studentResult = studentResult;
+    }
+}

--- a/test/org/nutz/dao/test/normal/psql/StudentResult.java
+++ b/test/org/nutz/dao/test/normal/psql/StudentResult.java
@@ -1,0 +1,45 @@
+package org.nutz.dao.test.normal.psql;
+
+import java.math.BigDecimal;
+
+import org.nutz.json.Json;
+import org.nutz.json.JsonFormat;
+import org.nutz.lang.Lang;
+
+public class StudentResult {
+
+    private String mathematics;
+
+    private BigDecimal physics;
+
+    private int foreignLanguage;
+
+    public String getMathematics() {
+        return mathematics;
+    }
+
+    public void setMathematics(String mathematics) {
+        this.mathematics = mathematics;
+    }
+
+    public BigDecimal getPhysics() {
+        return physics;
+    }
+
+    public void setPhysics(BigDecimal physics) {
+        this.physics = physics;
+    }
+
+    public int getForeignLanguage() {
+        return foreignLanguage;
+    }
+
+    public void setForeignLanguage(int foreignLanguage) {
+        this.foreignLanguage = foreignLanguage;
+    }
+
+    public boolean equals(StudentResult otherResult) {
+        return Lang.equals(Json.toJson(this, JsonFormat.tidy()),
+                           Json.toJson(otherResult, JsonFormat.tidy()));
+    }
+}


### PR DESCRIPTION
1）PsqlJsonAdaptor 只解决了使用 POJO 的情况，用 Chain 来操作的话还未解决，#921
2）使用数组的时候需要 POJO 实现`带一个参数的静态工厂方法`或者`带一个参数的构造函数`，不然无法把数据库字段的值映射到 POJO 的字段中
