### PR TITLE
multiple code improvements: squid:S1213, squid:ClassVariableVisibilityCheck, squid:S1155, squid:S00117, squid:S1125, squid:S1319

### DIFF
--- a/src/org/nutz/aop/AbstractClassAgent.java
+++ b/src/org/nutz/aop/AbstractClassAgent.java
@@ -49,7 +49,7 @@ public abstract class AbstractClassAgent implements ClassAgent {
         Class<T> newClass = try2Load(newName, klass.getClassLoader());
         if (newClass != null)
             return newClass;
-        if (checkClass(klass) == false)
+        if (!checkClass(klass))
             return klass;
         Pair2[] pair2s = findMatchedMethod(klass);
         if (pair2s.length == 0)
@@ -75,7 +75,7 @@ public abstract class AbstractClassAgent implements ClassAgent {
                 continue;
             cList.add(constructor);
         }
-        if (cList.size() == 0)
+        if (cList.isEmpty())
             throw Lang.makeThrow("No non-private constructor founded,unable to create sub-class!");
         return cList.toArray(new Constructor[cList.size()]);
     }
@@ -83,8 +83,8 @@ public abstract class AbstractClassAgent implements ClassAgent {
     protected <T> boolean checkClass(Class<T> klass) {
         if (klass == null)
             return false;
-        String klass_name = klass.getName();
-        if (klass_name.endsWith(CLASSNAME_SUFFIX))
+        String klassName = klass.getName();
+        if (klassName.endsWith(CLASSNAME_SUFFIX))
             return false;
         if (klass.isInterface()
             || klass.isArray()
@@ -93,9 +93,9 @@ public abstract class AbstractClassAgent implements ClassAgent {
             || klass.isMemberClass()
             || klass.isAnnotation()
             || klass.isAnonymousClass())
-            throw Lang.makeThrow("%s is NOT a Top-Class!Creation FAIL!", klass_name);
+            throw Lang.makeThrow("%s is NOT a Top-Class!Creation FAIL!", klassName);
         if (Modifier.isFinal(klass.getModifiers()) || Modifier.isAbstract(klass.getModifiers()))
-            throw Lang.makeThrow("%s is final or abstract!Creation FAIL!", klass_name);
+            throw Lang.makeThrow("%s is final or abstract!Creation FAIL!", klassName);
         return true;
     }
 
@@ -124,29 +124,46 @@ public abstract class AbstractClassAgent implements ClassAgent {
             for (Pair p : pairs)
                 if (p.matcher.match(m))
                     mls.add(p.listener);
-            if (mls.size() > 0)
+            if (!mls.isEmpty())
                 p2.add(new Pair2(m, mls));
         }
         return p2.toArray(new Pair2[p2.size()]);
     }
 
     protected static class Pair {
+        MethodMatcher matcher;
+        MethodInterceptor listener;
+
         Pair(MethodMatcher matcher, MethodInterceptor listener) {
             this.matcher = matcher;
             this.listener = listener;
         }
-
-        MethodMatcher matcher;
-        MethodInterceptor listener;
     }
 
     protected static class Pair2 {
-        Pair2(Method method, ArrayList<MethodInterceptor> listeners) {
+        private Method method;
+        private List<MethodInterceptor> listeners;
+
+        Pair2(Method method, List<MethodInterceptor> listeners) {
             this.method = method;
             this.listeners = listeners;
         }
 
-        public Method method;
-        public ArrayList<MethodInterceptor> listeners;
+        public Method getMethod() {
+            return method;
+        }
+
+        public void setMethod(Method method) {
+            this.method = method;
+        }
+
+        public List<MethodInterceptor> getListeners() {
+            return listeners;
+        }
+
+        public void setListeners(List<MethodInterceptor> listeners) {
+            this.listeners = listeners;
+        }
+        
     }
 }

--- a/src/org/nutz/aop/asm/AsmClassAgent.java
+++ b/src/org/nutz/aop/asm/AsmClassAgent.java
@@ -39,8 +39,8 @@ public class AsmClassAgent extends AbstractClassAgent {
         List<MethodInterceptor>[] methodInterceptorList = new List[pair2s.length];
         for (int i = 0; i < pair2s.length; i++) {
             Pair2 pair2 = pair2s[i];
-            methodArray[i] = pair2.method;
-            methodInterceptorList[i] = pair2.listeners;
+            methodArray[i] = pair2.getMethod();
+            methodInterceptorList[i] = pair2.getListeners();
         }
         byte[] bytes = ClassY.enhandClass(klass, newName, methodArray, constructors);
         //Files.write(new File(newName), bytes);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1213 The members of an interface declaration or class should appear in a pre-defined order,
squid:ClassVariableVisibilityCheck Class variable fields should not have public accessibility,
squid:S1155 Collection.isEmpty() should be used to test for emptiness,
squid:S00117 Local variable and method parameter names should comply with a naming convention,
squid:S1125 Literal boolean values should not be used in condition expressions,
squid:S1319 Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList".
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1213
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AClassVariableVisibilityCheck
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1155
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS00117
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1125
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1319
Please let me know if you have any questions.
George Kankava