### PR TITLE
Multiple code improvements - squid:S1192, squid:CommentedOutCodeLine

### DIFF
--- a/src/org/nutz/aop/asm/AopMethodAdapter.java
+++ b/src/org/nutz/aop/asm/AopMethodAdapter.java
@@ -13,6 +13,8 @@ import org.nutz.repo.org.objectweb.asm.Type;
  */
 class AopMethodAdapter extends NormalMethodAdapter implements Opcodes {
 
+    private static final String ORG_NUTZ_AOP_INTERCEPTOR_CHAIN = "org/nutz/aop/InterceptorChain";
+
     int methodIndex;
 
     String myName;
@@ -49,7 +51,7 @@ class AopMethodAdapter extends NormalMethodAdapter implements Opcodes {
         Label l2 = new Label();
         mv.visitTryCatchBlock(l0, l1, l2, "java/lang/Throwable");
         mv.visitLabel(l0);
-        mv.visitTypeInsn(NEW, "org/nutz/aop/InterceptorChain");
+        mv.visitTypeInsn(NEW, ORG_NUTZ_AOP_INTERCEPTOR_CHAIN);
         mv.visitInsn(DUP);
         visitX(methodIndex);
         mv.visitVarInsn(ALOAD, 0);
@@ -61,11 +63,11 @@ class AopMethodAdapter extends NormalMethodAdapter implements Opcodes {
         mv.visitInsn(AALOAD);
         loadArgsAsArray();
         mv.visitMethodInsn(    INVOKESPECIAL,
-                            "org/nutz/aop/InterceptorChain",
+                            ORG_NUTZ_AOP_INTERCEPTOR_CHAIN,
                             "<init>",
                             "(ILjava/lang/Object;Ljava/lang/reflect/Method;Ljava/util/List;[Ljava/lang/Object;)V");
         mv.visitMethodInsn(    INVOKEVIRTUAL,
-                            "org/nutz/aop/InterceptorChain",
+                            ORG_NUTZ_AOP_INTERCEPTOR_CHAIN,
                             "doChain",
                             "()Lorg/nutz/aop/InterceptorChain;");
 
@@ -74,7 +76,7 @@ class AopMethodAdapter extends NormalMethodAdapter implements Opcodes {
                 mv.visitInsn(POP);
             } else {
                 mv.visitMethodInsn(    INVOKEVIRTUAL,
-                                    "org/nutz/aop/InterceptorChain",
+                                    ORG_NUTZ_AOP_INTERCEPTOR_CHAIN,
                                     "getReturn",
                                     "()Ljava/lang/Object;");
                 AsmHelper.checkCast(returnType,mv);
@@ -88,8 +90,6 @@ class AopMethodAdapter extends NormalMethodAdapter implements Opcodes {
         mv.visitLabel(l2);
         mv.visitVarInsn(ASTORE, 3);
         mv.visitVarInsn(ALOAD, 3);
-        // mv.visitMethodInsn(INVOKESTATIC, "org/nutz/lang/Lang", "wrapThrow",
-        // "(Ljava/lang/Throwable;)Ljava/lang/RuntimeException;");
         mv.visitInsn(ATHROW);
         mv.visitLabel(l3);
         mv.visitInsn(RETURN);

--- a/src/org/nutz/aop/asm/AsmClassAgent.java
+++ b/src/org/nutz/aop/asm/AsmClassAgent.java
@@ -43,7 +43,6 @@ public class AsmClassAgent extends AbstractClassAgent {
             methodInterceptorList[i] = pair2.listeners;
         }
         byte[] bytes = ClassY.enhandClass(klass, newName, methodArray, constructors);
-        //Files.write(new File(newName), bytes);
         Class<T> newClass = (Class<T>) cd.define(newName, bytes, klass.getClassLoader());
         try {
             Mirror<T> mirror = Mirror.me(newClass);

--- a/src/org/nutz/aop/asm/AsmHelper.java
+++ b/src/org/nutz/aop/asm/AsmHelper.java
@@ -6,32 +6,35 @@ import org.nutz.repo.org.objectweb.asm.Type;
 
 final class AsmHelper implements Opcodes{
 
+    private static final String ORG_NUTZ_AOP_ASM_HELPER = "org/nutz/aop/asm/Helper";
+    private static final String VALUE_OF = "valueOf";
+
     static boolean packagePrivateData(Type type, MethodVisitor mv) {
         if (type.equals(Type.BOOLEAN_TYPE)) {
             mv.visitMethodInsn(    INVOKESTATIC,
                                 "java/lang/Boolean",
-                                "valueOf",
+                                VALUE_OF,
                                 "(Z)Ljava/lang/Boolean;");
         } else if (type.equals(Type.BYTE_TYPE)) {
-            mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "valueOf", "(B)Ljava/lang/Byte;");
+            mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", VALUE_OF, "(B)Ljava/lang/Byte;");
         } else if (type.equals(Type.CHAR_TYPE)) {
             mv.visitMethodInsn(    INVOKESTATIC,
                                 "java/lang/Character",
-                                "valueOf",
+                                VALUE_OF,
                                 "(C)Ljava/lang/Character;");
         } else if (type.equals(Type.SHORT_TYPE)) {
-            mv.visitMethodInsn(INVOKESTATIC, "java/lang/Short", "valueOf", "(S)Ljava/lang/Short;");
+            mv.visitMethodInsn(INVOKESTATIC, "java/lang/Short", VALUE_OF, "(S)Ljava/lang/Short;");
         } else if (type.equals(Type.INT_TYPE)) {
             mv.visitMethodInsn(    INVOKESTATIC,
                                 "java/lang/Integer",
-                                "valueOf",
+                                VALUE_OF,
                                 "(I)Ljava/lang/Integer;");
         } else if (type.equals(Type.LONG_TYPE)) {
-            mv.visitMethodInsn(INVOKESTATIC, "java/lang/Long", "valueOf", "(J)Ljava/lang/Long;");
+            mv.visitMethodInsn(INVOKESTATIC, "java/lang/Long", VALUE_OF, "(J)Ljava/lang/Long;");
         } else if (type.equals(Type.FLOAT_TYPE)) {
-            mv.visitMethodInsn(INVOKESTATIC, "java/lang/Float", "valueOf", "(F)Ljava/lang/Float;");
+            mv.visitMethodInsn(INVOKESTATIC, "java/lang/Float", VALUE_OF, "(F)Ljava/lang/Float;");
         } else if (type.equals(Type.DOUBLE_TYPE)) {
-            mv.visitMethodInsn(INVOKESTATIC, "java/lang/Double", "valueOf", "(D)Ljava/lang/Double;");
+            mv.visitMethodInsn(INVOKESTATIC, "java/lang/Double", VALUE_OF, "(D)Ljava/lang/Double;");
         } else {
             return false;
         }
@@ -41,43 +44,43 @@ final class AsmHelper implements Opcodes{
     static void unpackagePrivateData(Type type, MethodVisitor mv) {
         if (type.equals(Type.BOOLEAN_TYPE)) {
             mv.visitMethodInsn(    INVOKESTATIC,
-                                "org/nutz/aop/asm/Helper",
-                                "valueOf",
+                                ORG_NUTZ_AOP_ASM_HELPER,
+                                VALUE_OF,
                                 "(Ljava/lang/Boolean;)Z");
         } else if (type.equals(Type.BYTE_TYPE)) {
             mv.visitMethodInsn(    INVOKESTATIC,
-                                "org/nutz/aop/asm/Helper",
-                                "valueOf",
+                                ORG_NUTZ_AOP_ASM_HELPER,
+                                VALUE_OF,
                                 "(Ljava/lang/Byte;)B");
         } else if (type.equals(Type.CHAR_TYPE)) {
             mv.visitMethodInsn(    INVOKESTATIC,
-                                "org/nutz/aop/asm/Helper",
-                                "valueOf",
+                                ORG_NUTZ_AOP_ASM_HELPER,
+                                VALUE_OF,
                                 "(Ljava/lang/Character;)C");
         } else if (type.equals(Type.SHORT_TYPE)) {
             mv.visitMethodInsn(    INVOKESTATIC,
-                                "org/nutz/aop/asm/Helper",
-                                "valueOf",
+                                ORG_NUTZ_AOP_ASM_HELPER,
+                                VALUE_OF,
                                 "(Ljava/lang/Short;)S");
         } else if (type.equals(Type.INT_TYPE)) {
             mv.visitMethodInsn(    INVOKESTATIC,
-                                "org/nutz/aop/asm/Helper",
-                                "valueOf",
+                                ORG_NUTZ_AOP_ASM_HELPER,
+                                VALUE_OF,
                                 "(Ljava/lang/Integer;)I");
         } else if (type.equals(Type.LONG_TYPE)) {
             mv.visitMethodInsn(    INVOKESTATIC,
-                                "org/nutz/aop/asm/Helper",
-                                "valueOf",
+                                ORG_NUTZ_AOP_ASM_HELPER,
+                                VALUE_OF,
                                 "(Ljava/lang/Long;)J");
         } else if (type.equals(Type.FLOAT_TYPE)) {
             mv.visitMethodInsn(    INVOKESTATIC,
-                                "org/nutz/aop/asm/Helper",
-                                "valueOf",
+                                ORG_NUTZ_AOP_ASM_HELPER,
+                                VALUE_OF,
                                 "(Ljava/lang/Float;)F");
         } else if (type.equals(Type.DOUBLE_TYPE)) {
             mv.visitMethodInsn(    INVOKESTATIC,
-                                "org/nutz/aop/asm/Helper",
-                                "valueOf",
+                                ORG_NUTZ_AOP_ASM_HELPER,
+                                VALUE_OF,
                                 "(Ljava/lang/Double;)D");
         }
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1192 - String literals should not be duplicated.
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
Please let me know if you have any questions.
George Kankava