### PR TITLE
multiple code improvements: squid:S1213, squid:S00105, squid:S3008, squid:S1197

### DIFF
--- a/src/org/nutz/aop/ClassAgent.java
+++ b/src/org/nutz/aop/ClassAgent.java
@@ -7,6 +7,8 @@ package org.nutz.aop;
  */
 public interface ClassAgent {
 
+    String CLASSNAME_SUFFIX = "$$NUTZAOP";
+
     /**
      * 定义一个新的类对象
      * 
@@ -28,6 +30,4 @@ public interface ClassAgent {
      * @return 添加完成后的ClassAgent
      */
     ClassAgent addInterceptor(MethodMatcher matcher, MethodInterceptor inte);
-
-    String CLASSNAME_SUFFIX = "$$NUTZAOP";
 }

--- a/src/org/nutz/aop/DefaultClassDefiner.java
+++ b/src/org/nutz/aop/DefaultClassDefiner.java
@@ -8,15 +8,15 @@ import org.nutz.lang.reflect.ReflectTool;
  * @author Wendal(wendal1985@gmail.com)
  */
 public class DefaultClassDefiner implements ClassDefiner {
-    
-    public static String DEBUG_DIR;
-    
+
+    public static String debugDir;
+
     private static ClassDefiner me = new DefaultClassDefiner();
-    
+
     public static ClassDefiner defaultOne() {
         return me;
     }
-	
+
     public Class<?> define(String className, byte[] bytes, ClassLoader loader) {
         try {
             //if (DEBUG_DIR != null)

--- a/src/org/nutz/aop/InterceptorChain.java
+++ b/src/org/nutz/aop/InterceptorChain.java
@@ -19,7 +19,7 @@ public class InterceptorChain {
 
     protected int methodIndex;
 
-    protected Object args[];
+    protected Object[] args;
 
     protected AopCallback callingObj;
 
@@ -27,7 +27,7 @@ public class InterceptorChain {
 
     protected List<MethodInterceptor> miList;
 
-    private static Log LOG = Logs.get();
+    private static Log log = Logs.get();
 
     private boolean invoked = false;
 
@@ -71,7 +71,7 @@ public class InterceptorChain {
      */
     public void invoke() throws Throwable {
         if (invoked)
-            LOG.warnf("!! Calling Method more than once! Method --> %s", callingMethod.toString());
+            log.warnf("!! Calling Method more than once! Method --> %s", callingMethod.toString());
         else
             invoked = true;
         this.returnValue = callingObj._aop_invoke(methodIndex, args);

--- a/test/org/nutz/lang/reflect/FastClassFactoryTest.java
+++ b/test/org/nutz/lang/reflect/FastClassFactoryTest.java
@@ -28,7 +28,7 @@ public class FastClassFactoryTest extends Assert {
 
     @Test
     public void testInvokeObjectMethodObjectArray() throws InvocationTargetException {
-        DefaultClassDefiner.DEBUG_DIR = "/nutz_fastclass/";
+        DefaultClassDefiner.debugDir = "/nutz_fastclass/";
         FastClass fc = FastClassFactory.get(Pet.class);
         //net.sf.cglib.reflect.FastClass fc2 = net.sf.cglib.reflect.FastClass.create(Pet.class);
         Mirror<Pet> mirror = Mirror.me(Pet.class);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1213 The members of an interface declaration or class should appear in a pre-defined order,
squid:S00105 Tabulation characters should not be used,
squid:S3008 Static non-final field names should comply with a naming convention,
squid:S1197 Array designators "[]" should be on the type, not the variable
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1213
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS00105
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS3008
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1197
Please let me know if you have any questions.
George Kankava