### PR TITLE
Fix: ORA-00933: SQL 命令未正确结束

### DIFF
--- a/src/org/nutz/dao/util/Daos.java
+++ b/src/org/nutz/dao/util/Daos.java
@@ -358,8 +358,10 @@ public abstract class Daos {
     	String tmpTable = "as _nutz_tmp";
     	if (dao.meta().isDB2())
     	    tmpTable = "as nutz_tmp_" + R.UU32();
-    	else if (!dao.meta().isOracle())
-    		tmpTable += "_" + R.UU32();
+        else if (dao.meta().isOracle())
+            tmpTable = "";
+        else
+            tmpTable += "_" + R.UU32();
         Sql sql2 = Sqls.fetchInt("select count(1) from ("
                                  + sql
                                  + ")" + tmpTable);


### PR DESCRIPTION
Fix: ORA-00933: SQL 命令未正确结束

2016-7-12 17:9:31.172 DEBUG [main] Database info --> ORACLE:[Oracle - Oracle Database 11g Enterprise Edition Release 11.2.0.4.0 - 64bit Production
With the Partitioning, OLAP, Data Mining and Real Application Testing options]
...
2016-7-12 17:9:31.651 DEBUG [main] select count(1) from (select * from tx_daoup_user)as _nutz_tmp
2016-7-12 17:9:31.659 DEBUG [main] SQLException
java.sql.SQLSyntaxErrorException: ORA-00933: SQL 命令未正确结束