### PR TITLE
Lang.length(obj) 调一次清爽些

### DIFF
--- a/src/org/nutz/dao/impl/NutDao.java
+++ b/src/org/nutz/dao/impl/NutDao.java
@@ -136,13 +136,11 @@ public class NutDao extends DaoSupport implements Dao {
     }
 
     public <T> T insert(final T obj) {
-        final EntityOperator opt = _optBy(Lang.first(obj));
+        Object first = Lang.first(obj);
+        final EntityOperator opt = _optBy(first);
         if (null == opt)
             return null;
         int size = Lang.length(obj);
-        if (size < 1)
-        	return obj;
-    	Object first = Lang.first(obj);
     	opt.addInsert(opt.entity, first);
         if (size > 1) {
         	if (opt.getPojoListSize() == 1) {


### PR DESCRIPTION
        final EntityOperator opt = _optBy(Lang.first(obj));
        if (null == opt)
            return null;
        int size = Lang.length(obj);
        if (size < 1)
            return obj;
    	Object first = Lang.first(obj);

        这里两个return是两个保护性校验。正常情况下执行
		
        final EntityOperator opt = _optBy(Lang.first(obj));
        int size = Lang.length(obj);
        Object first = Lang.first(obj);
			
        也就是说first通常会执行到，虽然 Lang.first(obj) 的成本并不高，
        但是感觉调一次清爽些。
        另外在 null != opt 时，
        size 总是 >= 1的