### PR TITLE
HttpAdaptor 增强调整

### DIFF
--- a/src/org/nutz/mvc/ActionInfo.java
+++ b/src/org/nutz/mvc/ActionInfo.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.nutz.lang.Lang;
 import org.nutz.lang.util.ClassMeta;
 import org.nutz.lang.util.ClassMetaReader;
 
@@ -47,6 +48,8 @@ public class ActionInfo {
     private boolean pathTop;
     
     private ClassMeta meta;
+
+    private String[] paramNames;
     
     private Integer lineNumber;
     
@@ -99,8 +102,8 @@ public class ActionInfo {
         if (this.method != null && this.meta == null && parent.meta != null && parent.meta.type != null){
             if (parent.meta.type.equals(this.method.getDeclaringClass().getName())) {
                 String key = ClassMetaReader.getKey(this.method);
-                if (key != null)
-                    this.lineNumber = parent.meta.methodLines.get(key);
+                this.paramNames = Lang.collection2array(parent.meta.paramNames.get(key), String.class);
+                this.lineNumber = parent.meta.methodLines.get(key);
             }
         }
         
@@ -250,7 +253,11 @@ public class ActionInfo {
     public void setMeta(ClassMeta meta) {
         this.meta = meta;
     }
-    
+
+    public String[] getParamNames() {
+        return paramNames;
+    }
+
     public Integer getLineNumber() {
         return lineNumber;
     }

--- a/src/org/nutz/mvc/HttpAdaptor2.java
+++ b/src/org/nutz/mvc/HttpAdaptor2.java
@@ -1,0 +1,17 @@
+package org.nutz.mvc;
+
+/**
+ * 扩展原有 {@link HttpAdaptor} 的能力，
+ *
+ * @author MingzFan(Mingz.Fan@gmail.com)
+ */
+public interface HttpAdaptor2 extends HttpAdaptor {
+
+    /**
+     * 这是更高级的初始化方法，可以获得更多的初始化信息
+     *
+     * @see org.nutz.mvc.HttpAdaptor
+     */
+    void init(ActionInfo ai);
+
+}

--- a/src/org/nutz/mvc/adaptor/WhaleAdaptor.java
+++ b/src/org/nutz/mvc/adaptor/WhaleAdaptor.java
@@ -81,32 +81,29 @@ public class WhaleAdaptor extends PairAdaptor {
         if (Map.class.isAssignableFrom(clazz))
             return new MapSelfInjector();
 
-        if (null == param)
-            return super.evalInjectorBy(type, null);
-
-        String paramName = param.value();
+        String pn = null == param ? paramNames[curIndex] : param.value();
 
         // File
         if (File.class.isAssignableFrom(clazz))
-            return new FileInjector(paramName);
+            return new FileInjector(pn);
         // FileMeta
         if (FieldMeta.class.isAssignableFrom(clazz))
-            return new FileMetaInjector(paramName);
+            return new FileMetaInjector(pn);
         // TempFile
         if (TempFile.class.isAssignableFrom(clazz))
-            return new TempFileInjector(paramName);
+            return new TempFileInjector(pn);
         // InputStream
         if (InputStream.class.isAssignableFrom(clazz))
-            return new InputStreamInjector(paramName);
+            return new InputStreamInjector(pn);
         // Reader
         if (Reader.class.isAssignableFrom(clazz))
-            return new ReaderInjector(paramName);
+            return new ReaderInjector(pn);
         // List
         //if (List.class.isAssignableFrom(clazz)) {
         //    return new MapListInjector(paramName);
         //}
         if (TempFile[].class.isAssignableFrom(clazz)) {
-            return new TempFileArrayInjector(paramName);
+            return new TempFileArrayInjector(pn);
         }
         // Other
         return super.evalInjectorBy(type, param);

--- a/src/org/nutz/mvc/impl/processor/AdaptorProcessor.java
+++ b/src/org/nutz/mvc/impl/processor/AdaptorProcessor.java
@@ -2,17 +2,14 @@ package org.nutz.mvc.impl.processor;
 
 import java.util.List;
 
-import org.nutz.mvc.ActionContext;
-import org.nutz.mvc.ActionInfo;
-import org.nutz.mvc.HttpAdaptor;
-import org.nutz.mvc.NutConfig;
+import org.nutz.mvc.*;
 import org.nutz.mvc.adaptor.PairAdaptor;
 
 /**
  * 
  * @author zozoh(zozohtnt@gmail.com)
  * @author wendal(wendal1985@gmail.com)
- * 
+ * @author MingzFan(Mingz.Fan@gmail.com)
  */
 public class AdaptorProcessor extends AbstractProcessor {
 
@@ -37,7 +34,10 @@ public class AdaptorProcessor extends AbstractProcessor {
         HttpAdaptor re = evalObj(config, ai.getAdaptorInfo());
         if (null == re)
             re = new PairAdaptor();
-        re.init(ai.getMethod());
+        if (re instanceof HttpAdaptor2)
+            ((HttpAdaptor2) re).init(ai);
+        else
+            re.init(ai.getMethod());
         return re;
     }
 }

--- a/src/org/nutz/mvc/upload/UploadAdaptor.java
+++ b/src/org/nutz/mvc/upload/UploadAdaptor.java
@@ -16,6 +16,7 @@ import org.nutz.filepool.NutFilePool;
 import org.nutz.lang.Lang;
 import org.nutz.log.Log;
 import org.nutz.log.Logs;
+import org.nutz.mvc.ActionInfo;
 import org.nutz.mvc.Mvcs;
 import org.nutz.mvc.adaptor.PairAdaptor;
 import org.nutz.mvc.adaptor.ParamInjector;
@@ -132,26 +133,23 @@ public class UploadAdaptor extends PairAdaptor {
         if (Map.class.isAssignableFrom(clazz))
             return new MapSelfInjector();
 
-        if (null == param)
-            return super.evalInjectorBy(type, null);
-
-        String paramName = param.value();
+        String pn = null == param ? paramNames[curIndex] : param.value();
 
         // File
         if (File.class.isAssignableFrom(clazz))
-            return new org.nutz.mvc.upload.injector.FileInjector(paramName);
+            return new org.nutz.mvc.upload.injector.FileInjector(pn);
         // FileMeta
         if (FieldMeta.class.isAssignableFrom(clazz))
-            return new org.nutz.mvc.upload.injector.FileMetaInjector(paramName);
+            return new org.nutz.mvc.upload.injector.FileMetaInjector(pn);
         // TempFile
         if (TempFile.class.isAssignableFrom(clazz))
-            return new TempFileInjector(paramName);
+            return new TempFileInjector(pn);
         // InputStream
         if (InputStream.class.isAssignableFrom(clazz))
-            return new InputStreamInjector(paramName);
+            return new InputStreamInjector(pn);
         // Reader
         if (Reader.class.isAssignableFrom(clazz))
-            return new ReaderInjector(paramName);
+            return new ReaderInjector(pn);
         // List
         //if (List.class.isAssignableFrom(clazz)) {
         //    if (!Strings.isBlank(paramName) && paramName.startsWith("::"))
@@ -159,7 +157,7 @@ public class UploadAdaptor extends PairAdaptor {
         //    return new MapListInjector(paramName);
         //}
         if (TempFile[].class.isAssignableFrom(clazz)) {
-            return new TempFileArrayInjector(paramName);
+            return new TempFileArrayInjector(pn);
         }
         // Other
         return super.evalInjectorBy(type, param);
@@ -207,11 +205,11 @@ public class UploadAdaptor extends PairAdaptor {
     }
     
     @Override
-    public void init(Method method) {
+    public void init(ActionInfo ai) {
         if (this.method != null) {
             // 如果ioc配置中设置为单例了,那应该提前报错!! 解决方法 singleton : false
             throw new RuntimeException(new UploadException("Duplicate initialization is not allowed."));
         }
-        super.init(method);
+        super.init(ai);
     }
 }

--- a/test/org/nutz/mvc/testapp/adaptor/SimpleAdaptorTest.java
+++ b/test/org/nutz/mvc/testapp/adaptor/SimpleAdaptorTest.java
@@ -34,6 +34,24 @@ public class SimpleAdaptorTest extends BaseWebappTest {
     }
 
     @Test
+    public void test_err_param_anywhere() {
+        get("/adaptor/err/param/anywhere?id=ABC");
+        assertEquals(200, resp.getStatus());
+
+        get("/adaptor/err/param/anywhere/ABC");
+        assertEquals(200, resp.getStatus());
+    }
+
+    @Test
+    public void test_err_param_with_pathargs() {
+        get("/adaptor/err/param/pathargs/a?id=ABC");
+        assertEquals(200, resp.getStatus());
+
+        get("/adaptor/err/param/pathargs/a/ABC");
+        assertEquals(200, resp.getStatus());
+    }
+
+    @Test
     public void test_json_map_type() {
         resp = post("/adaptor/json/type", "{'abc': 123456}");
         if (resp.getStatus() != 200) {
@@ -106,7 +124,19 @@ public class SimpleAdaptorTest extends BaseWebappTest {
         assertEquals(200, get("/adaptor/param_without_param").getStatus());
         assertEquals("[\"1\", \"2\", \"4\", \"3\"]".replaceAll(" ", ""), get("/adaptor/param_without_param?uids=1,2,4,3").getContent().replaceAll(" ", ""));
     }
-    
+
+    @Test
+    public void test_object_without_param() {
+        assertEquals(200, get("/adaptor/object_without_param").getStatus());
+        assertEquals("{\"name\": \"object\"}".replaceAll(" ", ""), get("/adaptor/object_without_param?name=object").getContent().replaceAll(" ", ""));
+    }
+
+    @Test
+    public void test_path_args_and_object_without_param() {
+        assertEquals(200, get("/adaptor/path_args_and_object_without_param/1").getStatus());
+        assertEquals("{\"name\": \"1\"}".replaceAll(" ", ""), get("/adaptor/path_args_and_object_without_param/1?name=object").getContent().replaceAll(" ", ""));
+    }
+
     @Test
     public void issue_1069() {
         resp = post("/adaptor/issue1069", "");

--- a/test/org/nutz/mvc/testapp/classes/action/adaptor/AdaptorTestModule.java
+++ b/test/org/nutz/mvc/testapp/classes/action/adaptor/AdaptorTestModule.java
@@ -84,6 +84,20 @@ public class AdaptorTestModule extends BaseWebappTest {
         TestCase.assertNotNull(errCtx.getErrors()[0]);
     }
 
+    // 传入的id,会是一个非法的字符串!!
+    @At({"/err/param/anywhere", "/err/param/anywhere/?"})
+    public void errParamAnyWhere(AdaptorErrorContext errCtx, @Param("id") long id) {
+        TestCase.assertNotNull(errCtx);
+        TestCase.assertNotNull(errCtx.getErrors()[1]);
+    }
+
+    // 传入的id,会是一个非法的字符串!!
+    @At({"/err/param/pathargs/?", "/err/param/pathargs/?/?"})
+    public void errParamWithPathArgs(AdaptorErrorContext errCtx, String a, @Param("id") long id) {
+        TestCase.assertNotNull(errCtx);
+        TestCase.assertNotNull(errCtx.getErrors()[2]);
+    }
+
     @At("/json/type")
     @AdaptBy(type = JsonAdaptor.class)
     public void jsonMapType(Map<String, Double> map) {
@@ -119,7 +133,20 @@ public class AdaptorTestModule extends BaseWebappTest {
     public Object test_param_without_param(String uid, String[] uids, HttpServletRequest req) {
         return uids;
     }
-    
+
+    @At("/object_without_param")
+    @Ok("json:compact")
+    public Object test_object_without_param(Pet pet, HttpServletRequest req) {
+        return pet;
+    }
+
+    @At("/path_args_and_object_without_param/?")
+    @Ok("json:compact")
+    public Object test_path_args_and_object_without_param(String name, Pet pet, HttpServletRequest req) {
+        pet.setName(name);
+        return pet;
+    }
+
     @At("/issue1069")
     @Ok("raw")
     public Object test_issue1069(@Param("..")Issue1069 issue1069) {


### PR DESCRIPTION
Change: 
1. 入口方法的POJO参数不声明 Param 注解也可以注入，效果与 @Param("..") 保持一致
2. ActionInfo 增加 paramNames 属性，使 Processor 在初始化时可以获取参数名称数组
3. 新增 HttpAdaptor2 接口（继承自 HttpAdaptor ），提供更高级别的init方法
4. AbstractAdaptor 由实现 HttpAdaptor 接口调整为实现 HttpAdaptor2 接口
5. 当入口函数需要定义 AdaptorErrorContext 类型参数时，不再硬性要求定义为入口函数的最后一个参数，可以为入口函数中任意位置的参数（存在多个 AdaptorErrorContext 参数时只以第一个为准）
6. 增加上述调整相应的 test case