### PR TITLE
fix:入口函数存在多个 AdaptorErrorContext 参数的时候可能会出现路径参数对应错乱及没有以第一个 AdaptorErrorContext 参数为准的问题

### DIFF
--- a/src/org/nutz/mvc/adaptor/AbstractAdaptor.java
+++ b/src/org/nutz/mvc/adaptor/AbstractAdaptor.java
@@ -99,6 +99,7 @@ public abstract class AbstractAdaptor implements HttpAdaptor2 {
                 // 多个 AdaptorErrorContext 类型的参数时，以第一个为准
                 if (errCtxIndex == -1)
                     errCtxIndex = i;
+
                 continue;
             }
 
@@ -268,17 +269,18 @@ public abstract class AbstractAdaptor implements HttpAdaptor2 {
             throw Lang.wrapThrow(e);
         }
 
-        // AdaptorErrorContext 类型的参数混在路径参数之中或在路径参数之前时，len 需要加 1 才能标识最后一个路径参数的索引位置
-        int len = Math.min(args.length, null == pathArgs ? 0 : (errCtxIndex > -1 && errCtxIndex < pathArgs.length ? pathArgs.length + 1 : pathArgs.length));
+        // 当前路径参数的索引
+        int curPathArgIdx = 0;
+        int len = null == pathArgs ? 0 : pathArgs.length;
         for (int i = 0; i < args.length; i++) {
             // 如果这个参数是 AdaptorErrorContext 类型的，就跳过
             if (AdaptorErrorContext.class.isAssignableFrom(argTypes[i]))
                 continue;
 
             Object value = null;
-            if (i < len) { // 路径参数
-                // 在 AdaptorErrorContext 类型的参数之后的路径参数所对应的路径参数值的下标需要减 1
-                value = null == pathArgs ? null : pathArgs[errCtxIndex > -1 && errCtxIndex < i ? i - 1 : i];
+            if (curPathArgIdx < len) { // 路径参数
+                value = pathArgs[curPathArgIdx];
+                curPathArgIdx++;
             } else { // 普通参数
                 value = obj;
             }

--- a/src/org/nutz/mvc/adaptor/AbstractAdaptor.java
+++ b/src/org/nutz/mvc/adaptor/AbstractAdaptor.java
@@ -96,7 +96,9 @@ public abstract class AbstractAdaptor implements HttpAdaptor2 {
 
             // AdaptorErrorContext 类型的参数不需要生成注入器，记录下参数的下标就好了
             if (AdaptorErrorContext.class.isAssignableFrom(argTypes[i])) {
-                errCtxIndex = i;
+                // 多个 AdaptorErrorContext 类型的参数时，以第一个为准
+                if (errCtxIndex == -1)
+                    errCtxIndex = i;
                 continue;
             }
 
@@ -270,7 +272,7 @@ public abstract class AbstractAdaptor implements HttpAdaptor2 {
         int len = Math.min(args.length, null == pathArgs ? 0 : (errCtxIndex > -1 && errCtxIndex < pathArgs.length ? pathArgs.length + 1 : pathArgs.length));
         for (int i = 0; i < args.length; i++) {
             // 如果这个参数是 AdaptorErrorContext 类型的，就跳过
-            if (i == errCtxIndex)
+            if (AdaptorErrorContext.class.isAssignableFrom(argTypes[i]))
                 continue;
 
             Object value = null;

--- a/test/org/nutz/mvc/testapp/adaptor/SimpleAdaptorTest.java
+++ b/test/org/nutz/mvc/testapp/adaptor/SimpleAdaptorTest.java
@@ -52,6 +52,24 @@ public class SimpleAdaptorTest extends BaseWebappTest {
     }
 
     @Test
+    public void test_multi_err_ctxs() {
+        get("/adaptor/multi/err/ctxs/a?id=ABC");
+        assertEquals(200, resp.getStatus());
+
+        get("/adaptor/multi/err/ctxs/a/ABC");
+        assertEquals(200, resp.getStatus());
+    }
+
+    @Test
+    public void test_multi_err_ctxs2() {
+        get("/adaptor/multi/err/ctxs2/a/b?id=ABC");
+        assertEquals(200, resp.getStatus());
+
+        get("/adaptor/multi/err/ctxs2/a/b/ABC");
+        assertEquals(200, resp.getStatus());
+    }
+
+    @Test
     public void test_json_map_type() {
         resp = post("/adaptor/json/type", "{'abc': 123456}");
         if (resp.getStatus() != 200) {

--- a/test/org/nutz/mvc/testapp/classes/action/adaptor/AdaptorTestModule.java
+++ b/test/org/nutz/mvc/testapp/classes/action/adaptor/AdaptorTestModule.java
@@ -96,6 +96,28 @@ public class AdaptorTestModule extends BaseWebappTest {
     public void errParamWithPathArgs(AdaptorErrorContext errCtx, String a, @Param("id") long id) {
         TestCase.assertNotNull(errCtx);
         TestCase.assertNotNull(errCtx.getErrors()[2]);
+        TestCase.assertNotNull(a);
+    }
+
+    // 传入的id,会是一个非法的字符串!!
+    @At({"/multi/err/ctxs/?", "/multi/err/ctxs/?/?"})
+    public void multiErrCtxs(AdaptorErrorContext errCtx, String a, AdaptorErrorContext errCtx2, @Param("id") long id, AdaptorErrorContext errCtx3) {
+        TestCase.assertNotNull(errCtx);
+        TestCase.assertNotNull(errCtx.getErrors()[3]);
+        TestCase.assertNotNull(a);
+        TestCase.assertNull(errCtx2);
+        TestCase.assertNull(errCtx3);
+    }
+
+    // 传入的id,会是一个非法的字符串!!
+    @At({"/multi/err/ctxs2/?/?", "/multi/err/ctxs2/?/?/?"})
+    public void multiErrCtxs(String a, AdaptorErrorContext errCtx, AdaptorErrorContext errCtx2, String b, @Param("id") long id, AdaptorErrorContext errCtx3) {
+        TestCase.assertNotNull(errCtx);
+        TestCase.assertNotNull(errCtx.getErrors()[4]);
+        TestCase.assertNotNull(a);
+        TestCase.assertNotNull(b);
+        TestCase.assertNull(errCtx2);
+        TestCase.assertNull(errCtx3);
     }
 
     @At("/json/type")


### PR DESCRIPTION
fix:
1. 入口函数存在多个 AdaptorErrorContext 参数的时候可能会出现路径参数对应错乱及没有以第一个 AdaptorErrorContext 参数为准的问题

chang:
2. 增加入口函数存在多个 AdaptorErrorContext 参数的 test case