### PR TITLE
fix 存在不同ioc不同classloader 相同 bean name 被错误缓存的bug #1395

### DIFF
--- a/src/org/nutz/lang/reflect/FastMethodFactory.java
+++ b/src/org/nutz/lang/reflect/FastMethodFactory.java
@@ -29,7 +29,7 @@ public class FastMethodFactory implements Opcodes {
     
     protected static FastMethod make(final Method method) {
         Class<?> klass = method.getDeclaringClass();
-        String descriptor = Type.getMethodDescriptor(method);
+        String descriptor = Type.getMethodDescriptor(method) + method.getDeclaringClass().getClassLoader();
         String key = "$FM$" + method.getName() + "$" + Lang.md5(descriptor);
         String className = klass.getName() + key;
         if (klass.getName().startsWith("java"))
@@ -73,7 +73,7 @@ public class FastMethodFactory implements Opcodes {
 
     protected static FastMethod make(Constructor<?> constructor) {
         Class<?> klass = constructor.getDeclaringClass();
-        String descriptor = Type.getConstructorDescriptor(constructor);
+        String descriptor = Type.getConstructorDescriptor(constructor) + constructor.getDeclaringClass().getClassLoader();;
         String key = Lang.md5(descriptor);
         String className = klass.getName() + "$FC$" + key;
         if (klass.getName().startsWith("java"))


### PR DESCRIPTION

理论上修改这个

````
    /**
     * Returns the descriptor corresponding to the given method.
     * 
     * @param m
     *            a {@link Method Method} object.
     * @return the descriptor of the given method.
     */
    public static String getMethodDescriptor(final Method m) {
        Class<?>[] parameters = m.getParameterTypes();
        StringBuilder buf = new StringBuilder();
        buf.append('(');
        for (int i = 0; i < parameters.length; ++i) {
            getDescriptor(buf, parameters[i]);
        }
        buf.append(')');
        getDescriptor(buf, m.getReturnType());
        return buf.toString();
    }



/**
     * Returns the descriptor corresponding to the given method.
     * 
     * @param m
     *            a {@link Method Method} object.
     * @return the descriptor of the given method.
     */
    public static String getMethodDescriptor(final Method m) {
        Class<?>[] parameters = m.getParameterTypes();
        StringBuilder buf = new StringBuilder(m.getDeclaringClass().getClassLoader().toString());
        buf.append('(');
        for (int i = 0; i < parameters.length; ++i) {
            getDescriptor(buf, parameters[i]);
        }
        buf.append(')');
        getDescriptor(buf, m.getReturnType());
        return buf.toString();
    }

````
但是我不确定 descriptor是否在别处有解开。所以保险起见还是之修改 FastMethodFactory

