### PR TITLE
Criteria 接口中andIn方法和andNotIn增加int[],long[],String[],List<Integer>,List<Long>,List<String>参数

### DIFF
--- a/src/org/nutz/dao/util/cri/Exps.java
+++ b/src/org/nutz/dao/util/cri/Exps.java
@@ -53,9 +53,17 @@ public abstract class Exps {
     public static IntRange inInt(String name, int... ids) {
         return new IntRange(name, ids);
     }
+    
+    public static IntRange inInt(String name, Integer[] ids) {
+    	return new IntRange(name, ids);
+    }
 
     public static LongRange inLong(String name, long... ids) {
         return new LongRange(name, ids);
+    }
+    
+    public static LongRange inLong(String name, Long[] ids) {
+    	return new LongRange(name, ids);
     }
 
     public static NameRange inStr(String name, String... names) {

--- a/src/org/nutz/dao/util/cri/IntRange.java
+++ b/src/org/nutz/dao/util/cri/IntRange.java
@@ -12,4 +12,12 @@ public class IntRange extends NumberRange {
             this.ids[i] = ids[i];
     }
     
+    IntRange(String name, Integer[] ids) {
+    	super(name);
+    	this.not = false;
+    	this.ids = new long[ids.length];
+    	for (int i = 0; i < ids.length; i++)
+    		this.ids[i] = ids[i];
+    }
+    
 }

--- a/src/org/nutz/dao/util/cri/LongRange.java
+++ b/src/org/nutz/dao/util/cri/LongRange.java
@@ -9,5 +9,13 @@ public class LongRange extends NumberRange {
         this.ids = ids;
         this.not = false;
     }
+    
+    LongRange(String name, Long[] ids) {
+    	super(name);
+    	this.ids =  new long[ids.length];
+    	for (int i = 0; i < ids.length; i++)
+    		this.ids[i] = ids[i];
+    	this.not = false;
+    }
 
 }

--- a/src/org/nutz/dao/util/cri/SqlExpressionGroup.java
+++ b/src/org/nutz/dao/util/cri/SqlExpressionGroup.java
@@ -86,12 +86,36 @@ public class SqlExpressionGroup extends AbstractPItem implements SqlExpression {
         return and(inLong(name, ids));
     }
 
+    public SqlExpressionGroup andInArray(String name, long[] ids) {
+    	return and(inLong(name, ids));
+    }
+    
+    public SqlExpressionGroup andInList(String name, List<Long> ids) {
+    	return and(inLong(name, ids.toArray(new Long[ids.size()])));
+    }
+    
     public SqlExpressionGroup andInIntArray(String name, int... ids) {
         return and(inInt(name, ids));
+    }
+    
+    public SqlExpressionGroup andInIntArray2(String name, int[] ids) {
+    	return and(inInt(name, ids));
+    }
+    
+    public SqlExpressionGroup andInIntList(String name, List<Integer> ids) {
+    	return and(inInt(name, ids.toArray(new Integer[ids.size()])));
     }
 
     public SqlExpressionGroup andIn(String name, String... names) {
         return and(inStr(name, names));
+    }
+    
+    public SqlExpressionGroup andInStrArray(String name, String[] names) {
+    	return and(inStr(name, names));
+    }
+    
+    public SqlExpressionGroup andInStrList(String name, List<String> names) {
+    	return and(inStr(name, names.toArray(new String[names.size()])));
     }
 
     public SqlExpressionGroup andInBySql(String name, String subSql, Object... args) {
@@ -113,13 +137,37 @@ public class SqlExpressionGroup extends AbstractPItem implements SqlExpression {
     public SqlExpressionGroup andNotIn(String name, long... ids) {
         return and(inLong(name, ids).not());
     }
-
+    
+    public SqlExpressionGroup andNotInArray(String name, long[] ids) {
+    	return and(inLong(name, ids).not());
+    }
+    
+    public SqlExpressionGroup andNotInList(String name, List<Long> ids) {
+    	return and(inLong(name, ids.toArray(new Long[ids.size()])).not());
+    }
+    
     public SqlExpressionGroup andNotIn(String name, int... ids) {
         return and(inInt(name, ids).not());
+    }
+    
+    public SqlExpressionGroup andNotInArray(String name, int[] ids) {
+    	return and(inInt(name, ids).not());
+    }
+    
+    public SqlExpressionGroup andNotInIntList(String name, List<Integer> ids) {
+    	return and(inInt(name, ids.toArray(new Integer[ids.size()])).not());
     }
 
     public SqlExpressionGroup andNotIn(String name, String... names) {
         return and(inStr(name, names).not());
+    }
+    
+    public SqlExpressionGroup andNotInArray(String name, String[] names) {
+    	return and(inStr(name, names).not());
+    }
+    
+    public SqlExpressionGroup andNotInStrList(String name, List<String> names) {
+    	return and(inStr(name, names.toArray(new String[names.size()])).not());
     }
 
     public SqlExpressionGroup andLike(String name, String value) {

--- a/test/org/nutz/dao/texp/CndTest.java
+++ b/test/org/nutz/dao/texp/CndTest.java
@@ -12,6 +12,7 @@ import org.nutz.dao.Cnd;
 import org.nutz.dao.Condition;
 import org.nutz.dao.FieldMatcher;
 import org.nutz.dao.entity.Entity;
+import org.nutz.dao.sql.Criteria;
 import org.nutz.dao.test.DaoCase;
 import org.nutz.dao.test.meta.Pet;
 import org.nutz.dao.util.cri.SqlExpression;
@@ -200,7 +201,158 @@ public class CndTest extends DaoCase {
         
         byte[] buf = Lang.toBytes(c);
         c = Lang.fromBytes(buf, Cnd.class);
-        
         assertEquals(" WHERE (f2=1) AND NOT (f3=1)", c.toString());
+    }
+    
+    /**
+     *  Criteria 接口测试int[]数组
+     */
+    @Test
+    public void test_in_by_criteria_int_array () {
+    	int[] ids = {1,2,3};
+    	Criteria cri = Cnd.cri();
+    	cri.where().andInIntArray2("nm", ids);
+    	assertEquals(" WHERE nm IN (1,2,3)", cri.toString());
+    }
+    
+    /**
+     *  Criteria 接口测试List&lt;Integer&gt;
+     */
+    @Test
+    public void test_in_by_criteria_int_list () {
+    	 List<Integer> ids = new ArrayList<Integer>();
+    	 ids.add(1);
+    	 ids.add(2);
+    	 ids.add(3);
+    	Criteria cri = Cnd.cri();
+    	cri.where().andInIntList("nm", ids);
+    	assertEquals(" WHERE nm IN (1,2,3)", cri.toString());
+    }
+    
+    /**
+     *  Criteria 接口测试long[]数组
+     */
+    @Test
+    public void test_in_by_criteria_long_array () {
+    	long[] ids = {1L,2L,3L};
+    	Criteria cri = Cnd.cri();
+    	cri.where().andInArray("nm", ids);
+    	assertEquals(" WHERE nm IN (1,2,3)", cri.toString());
+    }
+    
+    /**
+     *  Criteria 接口测试List&lt;Long&gt;
+     */
+    @Test
+    public void test_in_by_criteria_long_list () {
+    	List<Long> ids = new ArrayList<Long>();
+    	ids.add(1L);
+    	ids.add(2L);
+    	ids.add(3L);
+    	Criteria cri = Cnd.cri();
+    	cri.where().andInList("nm", ids);
+    	assertEquals(" WHERE nm IN (1,2,3)", cri.toString());
+    }
+    
+    /**
+     *  Criteria 接口测试String[]数组
+     */
+    @Test
+    public void test_in_by_criteria_string_array () {
+    	String[] ids = {"bj","sh","gz","sz"};
+    	Criteria cri = Cnd.cri();
+    	cri.where().andInStrArray("nm", ids);
+    	assertEquals(" WHERE nm IN ('bj','sh','gz','sz')", cri.toString());
+    }
+    
+    /**
+     *  Criteria 接口测试List&lt;String&gt;
+     */
+    @Test
+    public void test_in_by_criteria_string_list () {
+    	List<String> ids = new ArrayList<String>();
+    	ids.add("bj");
+    	ids.add("sh");
+    	ids.add("gz");
+    	ids.add("sz");
+    	Criteria cri = Cnd.cri();
+    	cri.where().andInStrList("nm", ids);
+    	assertEquals(" WHERE nm IN ('bj','sh','gz','sz')", cri.toString());
+    }
+    
+    /**
+     *  Criteria 接口测试int[]数组
+     */
+    @Test
+    public void test_not_in_by_criteria_int_array () {
+    	int[] ids = {1,2,3};
+    	Criteria cri = Cnd.cri();
+    	cri.where().andNotInArray("nm", ids);
+    	assertEquals(" WHERE nm NOT IN (1,2,3)", cri.toString());
+    }
+    
+    /**
+     *  Criteria 接口测试List&lt;Integer&gt;
+     */
+    @Test
+    public void test_not_in_by_criteria_int_list () {
+    	 List<Integer> ids = new ArrayList<Integer>();
+    	 ids.add(1);
+    	 ids.add(2);
+    	 ids.add(3);
+    	Criteria cri = Cnd.cri();
+    	cri.where().andNotInIntList("nm", ids);
+    	assertEquals(" WHERE nm NOT IN (1,2,3)", cri.toString());
+    }
+    
+    /**
+     *  Criteria 接口测试int[]数组
+     */
+    @Test
+    public void test_not_in_by_criteria_long_array () {
+    	int[] ids = {1,2,3};
+    	Criteria cri = Cnd.cri();
+    	cri.where().andNotInArray("nm", ids);
+    	assertEquals(" WHERE nm NOT IN (1,2,3)", cri.toString());
+    }
+    
+    /**
+     *  Criteria 接口测试List&lt;Integer&gt;
+     */
+    @Test
+    public void test_not_in_by_criteria_long_list () {
+    	List<Integer> ids = new ArrayList<Integer>();
+    	ids.add(1);
+    	ids.add(2);
+    	ids.add(3);
+    	Criteria cri = Cnd.cri();
+    	cri.where().andNotInIntList("nm", ids);
+    	assertEquals(" WHERE nm NOT IN (1,2,3)", cri.toString());
+    }
+    
+    /**
+     *  Criteria 接口测试String[]数组
+     */
+    @Test
+    public void test_not_in_by_criteria_string_array () {
+    	String[] ids = {"bj","sh","gz","sz"};
+    	Criteria cri = Cnd.cri();
+    	cri.where().andNotInArray("nm", ids);
+    	assertEquals(" WHERE nm NOT IN ('bj','sh','gz','sz')", cri.toString());
+    }
+    
+    /**
+     *  Criteria 接口测试List&lt;String&gt;
+     */
+    @Test
+    public void test_not_in_by_criteria_string_list () {
+    	List<String> ids = new ArrayList<String>();
+    	ids.add("bj");
+    	ids.add("sh");
+    	ids.add("gz");
+    	ids.add("sz");
+    	Criteria cri = Cnd.cri();
+    	cri.where().andNotInStrList("nm", ids);
+    	assertEquals(" WHERE nm NOT IN ('bj','sh','gz','sz')", cri.toString());
     }
 }


### PR DESCRIPTION
`Criteria cri = Cnd.cri();`
`cri.where().andIn("id", 3,4,5).andIn("name", "Peter", "Wendal", "Juqkai");`
原来方法中只有
`andNotIn(String name, long... ids)`
等方法，增加了
`int[],long[],String[],List<Integer>,List<Long>,List<String>`
等参数，便于调用。
例如：
`    	List<String> ids = new ArrayList<String>();`
`    	ids.add("bj");`
`    	ids.add("sh");`
`    	ids.add("gz");`
`    	ids.add("sz");`
`    	Criteria cri = Cnd.cri();`
`    	cri.where().andNotInStrList("nm", ids);`
单元测试也增加了
