### PR TITLE
update:文档Test中的maven依赖

### DIFF
--- a/doc/manual/testing/junit_testing.man
+++ b/doc/manual/testing/junit_testing.man
@@ -20,12 +20,6 @@
 			<version>1.r.60</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.12</version>
-			<scope>test</scope>
-		</dependency>
 		<!-- 可选, 安利一下mockito,模拟mock对象很方便 -->
 		<dependency>
 			<groupId>org.mockito</groupId>


### PR DESCRIPTION
**nutz-plugins-mock**已经传递了Junit-4依赖。
并且我们需要在**nutz-plugins-mock**的POM中，加入**hamcrest-core**依赖，Junit-4.12已经默认不包含此依赖。