### PR TITLE
文件池大小应该是指定的大小

### DIFF
--- a/src/org/nutz/filepool/NutFilePool.java
+++ b/src/org/nutz/filepool/NutFilePool.java
@@ -61,11 +61,9 @@ public class NutFilePool implements FilePool {
     }
 
     public File createFile(String suffix) {
-        if (size > 0 && cursor >= size)
+        if (size > 0 && cursor >= size-1)
             cursor = -1;
         long id = ++cursor;
-        if (size > 0 && id >= size)
-            Lang.makeThrow("Id (%d) is out of range (%d)", id, size);
         File re = Pools.getFileById(home, id, suffix);
         if (!re.exists())
             try {


### PR DESCRIPTION
指定文件池最多有多少个文件,如果

```
new NutFilePool("~/tmp/myfiles", 5);
```
那么现在该文件池中可以存储6个文件,文档写的是
```
// 将目录 ~/tmp/myfiles 作为一个文件池的根目录，里面最多同时有2000个文件
FilePool pool = new NutFilePool("~/tmp/myfiles", 2000);
```
是否需要调整呢?

以及67,68行的逻辑是多余的吧?