### PR TITLE
queryCount时需要设置count语句的Entity信息；

### DIFF
--- a/src/org/nutz/dao/util/Daos.java
+++ b/src/org/nutz/dao/util/Daos.java
@@ -365,6 +365,7 @@ public abstract class Daos {
         else
             tmpTable += "_" + R.UU32();
         Sql sql2 = Sqls.fetchLong("select count(1) from (" + sql.getSourceSql() + ")" + tmpTable);
+        sql2.setEntity(sql.getEntity());
         for (String key : sql.params().keys()) {
             sql2.setParam(key, sql.params().get(key));
         }


### PR DESCRIPTION
新建的count语句需要设置Entity信息才能正常解析原sql中的字段信息；