### PR TITLE
Change method name 'wrap' to 'createQuery'

### DIFF
--- a/src/org/nutz/dao/impl/jdbc/AbstractJdbcExpert.java
+++ b/src/org/nutz/dao/impl/jdbc/AbstractJdbcExpert.java
@@ -258,7 +258,7 @@ public abstract class AbstractJdbcExpert implements JdbcExpert, Configurable {
         }
     }
 
-    protected static List<DaoStatement> wrap(String... sqls) {
+    protected static List<DaoStatement> getNumberOfRecords(String... sqls) {
         List<DaoStatement> sts = new ArrayList<DaoStatement>(sqls.length);
         for (String sql : sqls)
             if (!Strings.isBlank(sql))


### PR DESCRIPTION
This class is used to represent .  This method named 'wrap' is to wrap an sql string and return a sql statement. Thus, the method name 'createQuery' is more intuitive than 'wrap'.