### PR TITLE
update:Inefficient use of keySet iterator instead of entrySet iterator

### DIFF
--- a/src/org/nutz/mapl/impl/MaplEach.java
+++ b/src/org/nutz/mapl/impl/MaplEach.java
@@ -28,7 +28,7 @@ public abstract class MaplEach {
      * @param obj
      */
     private void convertMap(Map<?, ?> obj) {
-        for(Object key : obj.keySet()){
+        for(Object key : obj.entrySet()){
             paths.addLast(key.toString());
             DLR(fetchPath(), obj.get(key));
             each(obj.get(key));

--- a/src/org/nutz/mapl/impl/MaplMerge.java
+++ b/src/org/nutz/mapl/impl/MaplMerge.java
@@ -91,7 +91,7 @@ public class MaplMerge {
         Map obj = new LinkedHashMap();
         for (int i = 0; i < objs.length; i++) {
             Map map = (Map) objs[i];
-            for (Object key : map.keySet()) {
+            for (Object key : map.entrySet()) {
                 Object objval = obj.get(key);
                 Object val = map.get(key);
                 if (objval != null && (val instanceof List || val instanceof Map)) {

--- a/src/org/nutz/mapl/impl/convert/ObjConvertImpl.java
+++ b/src/org/nutz/mapl/impl/convert/ObjConvertImpl.java
@@ -139,7 +139,7 @@ public class ObjConvertImpl implements MaplConvert {
             keyType = ts[0];
             valueType = ts[1];
         }
-        for (Object key : map.keySet()) {
+        for (Object key : map.entrySet()) {
             Object val = map.get(key);
             // 转换Key
             if (isLeaf(key)) {

--- a/src/org/nutz/mapl/impl/convert/StructureConvert.java
+++ b/src/org/nutz/mapl/impl/convert/StructureConvert.java
@@ -156,7 +156,7 @@ public class StructureConvert extends MaplEach implements MaplConvert{
      * @param path
      */
     private void loadMapRelation(Map<?, ?> obj, String path) {
-        for(Object key : obj.keySet()){
+        for(Object key : obj.entrySet()){
             Object val = obj.get(key);
             if(val instanceof String){
                 relation.put(path + space(path) + key.toString(), Lang.list(val.toString()));

--- a/src/org/nutz/mvc/WhaleFilter.java
+++ b/src/org/nutz/mvc/WhaleFilter.java
@@ -106,7 +106,7 @@ public class WhaleFilter implements Filter {
             UU32FilePool fp = new UU32FilePool(tmpPath);
             UploadingContext uc = new UploadingContext(fp);
             Mirror<UploadingContext> mirror = Mirror.me(uc);
-            for (Object _key : props.keySet()) {
+            for (Object _key : props.entrySet()) {
                 String key = _key.toString();
                 if (!key.startsWith("upload.")) {
                     continue;


### PR DESCRIPTION
This method accesses the value of a Map entry, using a key that was retrieved from a keySet iterator. It is more efficient to use an iterator on the entrySet of the map, to avoid the Map.get(key) lookup.