### PR TITLE
MANIFEST.MF文件中的Class-Path指定的jar文件没有被加入Scans文件列表问题

### DIFF
--- a/src/org/nutz/resource/Scans.java
+++ b/src/org/nutz/resource/Scans.java
@@ -492,7 +492,7 @@ public class Scans {
                             continue;
                         if (tmp.contains("Java"))
                             continue;
-                        //jars.add(tmp);
+                        addResourceLocation(ResourceLocation.jar(tmp));
                     }
                     else
                         registerLocation(new URL(url_str.substring(0, url_str.length() - referPath.length())));


### PR DESCRIPTION
https://get.nutz.io/  使用这个生成demo，勾选高级配置中“资源、配置文件放jar包外面”选项，application.properties文件中有
nutz.scans.paths=lib/
这个选项，直接在idea中开发的时候有这个选项是会报如下错误的
java.lang.RuntimeException: Fail to found file 'xxxx/target/classes\lib/'
去掉这个选项，实际打包的时候发现有部分iocbean没有被加载，跟踪发现是由于使用java -jar执行的时候，MANIFEST.MF文件中的Class-Path中指定的jar文件没有被加入到org.nutz.resource.Scans的扫描文件列表中。