### PR TITLE
Fix issue #1563: NutMap attach 另外一个map之后，序列化成json时两个内容都会出来，不符合预期

### DIFF
--- a/src/org/nutz/lang/util/NutMap.java
+++ b/src/org/nutz/lang/util/NutMap.java
@@ -368,8 +368,14 @@ public class NutMap extends LinkedHashMap<String, Object> implements NutBean {
     public Set<Map.Entry<String, Object>> entrySet() {
         if (null == _map)
             return super.entrySet();
+
         HashSet<Map.Entry<String, Object>> vals = new HashSet<Map.Entry<String, Object>>();
         vals.addAll(_map.entrySet());
+        for (Map.Entry entry : _map.entrySet()) {
+            // 如果本身也有这个entry，attach 上来的那个就要删除掉
+            if ( super.containsKey( entry.getKey()))
+                vals.remove( entry);
+        }
         vals.addAll(super.entrySet());
         return vals;
     }

--- a/test/org/nutz/lang/util/NutMapTest.java
+++ b/test/org/nutz/lang/util/NutMapTest.java
@@ -9,6 +9,8 @@ import java.util.List;
 
 import org.junit.Ignore;
 import org.junit.Test;
+import org.nutz.json.Json;
+import org.nutz.json.JsonFormat;
 import org.nutz.lang.Lang;
 
 public class NutMapTest {
@@ -90,6 +92,18 @@ public class NutMapTest {
         // 再获取看看
         List<NutMap> sList3 = nutMap.getAs("sList", List.class);
         assertEquals("s1", sList3.get(0).getString("nm"));
+    }
+
+    @Test
+    public void test_attach() {
+        NutMap nutMap = new NutMap();
+        nutMap.setv( "key", "nutMap1");
+        NutMap nutMap2 = new NutMap();
+        nutMap2.setv( "key", "nutMap2");
+        nutMap.attach( nutMap2);
+
+        assertEquals( "nutMap1", nutMap.get("key"));
+        assertEquals( "{\"key\":\"nutMap1\"}", Json.toJson( nutMap, JsonFormat.compact()));
     }
 
 }


### PR DESCRIPTION
有重复的key，主要是因为 entrySet 没有去重
