### PR TITLE
fix 读写分离不支持pg数据库的问题

### DIFF
--- a/src/org/nutz/dao/impl/sql/run/NutDaoRunner.java
+++ b/src/org/nutz/dao/impl/sql/run/NutDaoRunner.java
@@ -176,11 +176,21 @@ public class NutDaoRunner implements DaoRunner, Configurable {
     protected DataSource selectDataSource(Transaction t, DataSource master, ConnCallback callback) {
         if (this.slaveDataSource == null)
             return master;
-        if (t == null && callback instanceof DaoInterceptorChain) {
-            DaoInterceptorChain chain = (DaoInterceptorChain)callback;
-            DaoStatement[] sts = chain.getDaoStatements();
-            if (sts.length == 1 && (sts[0].isSelect() || sts[0].isForceExecQuery())) {
-                return slaveDataSource;
+        if(meta.getType() == DB.PSQL){
+            if (callback instanceof DaoInterceptorChain) {
+                DaoInterceptorChain chain = (DaoInterceptorChain)callback;
+                DaoStatement[] sts = chain.getDaoStatements();
+                if (sts.length == 1 && (sts[0].isSelect() || sts[0].isForceExecQuery())) {
+                    return slaveDataSource;
+                }
+            }
+        }else {
+            if (t == null && callback instanceof DaoInterceptorChain) {
+                DaoInterceptorChain chain = (DaoInterceptorChain)callback;
+                DaoStatement[] sts = chain.getDaoStatements();
+                if (sts.length == 1 && (sts[0].isSelect() || sts[0].isForceExecQuery())) {
+                    return slaveDataSource;
+                }
             }
         }
         return master;


### PR DESCRIPTION
nutz dao 读写分离 有两个判断条件
1  select, 2 不是事务

第二个条件不是必要的。取消掉可以兼容pg