### PR TITLE
如果JsonInjector.get函数的输入值为null零, 则更改错误消息。

### DIFF
--- a/src/org/nutz/mvc/adaptor/injector/JsonInjector.java
+++ b/src/org/nutz/mvc/adaptor/injector/JsonInjector.java
@@ -2,6 +2,7 @@ package org.nutz.mvc.adaptor.injector;
 
 import java.lang.reflect.Type;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
@@ -33,7 +34,7 @@ public class JsonInjector implements ParamInjector {
         if (null == name)
             return Mapl.maplistToObj(refer, type);
 
-        Map<String, Object> map = (Map<String, Object>)refer;
+        Map<String, Object> map = (Map<String, Object>) Objects.requireNonNull(refer, "refer");
         Object theObj = map.get(name);
         if (null == theObj)
             return null;

--- a/test/org/nutz/mvc/adaptor/injector/JsonInjectorTest.java
+++ b/test/org/nutz/mvc/adaptor/injector/JsonInjectorTest.java
@@ -1,0 +1,24 @@
+package org.nutz.mvc.adaptor.injector;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+/**
+ * @author Heewon Lee (pingpingy03@gmail.com)
+ */
+public class JsonInjectorTest {
+
+    @Test
+    public void test_null_refer() {
+        // 准备数据
+        JsonInjector inj = new JsonInjector(null, "");
+
+        // 检测
+        Throwable exc = assertThrows(NullPointerException.class, () -> {
+            inj.get(null, null, null, null);
+        });
+        assertEquals("refer", exc.getMessage());
+    }
+
+}


### PR DESCRIPTION
如果`Injector.get`函数中`refer`的值为`null`，则会导致 `NPE` 发生在变量更改之后。
这使得查看错误消息并确认错误是否由`refer`的值引起变得困难。
本次 PR 修改为在变量更改之前直接触发错误，以便返回更有利于进一步调试的信息。