### PR TITLE
给Mysql跟Postgresql添加保存JSON内容时的设置格式的ValueAdaptor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,13 +88,19 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>9.4-1206-jdbc41</version>
+            <version>42.7.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>mysql</groupId>
-            <artifactId>mysql-connector-java</artifactId>
-            <version>8.0.21</version>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <version>8.2.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mariadb.jdbc</groupId>
+            <artifactId>mariadb-java-client</artifactId>
+            <version>3.4.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/org/nutz/dao/impl/jdbc/mysql/MysqlJdbcExpert.java
+++ b/src/org/nutz/dao/impl/jdbc/mysql/MysqlJdbcExpert.java
@@ -196,7 +196,12 @@ public class MysqlJdbcExpert extends AbstractJdbcExpert {
     @Override
     public ValueAdaptor getAdaptor(MappingField ef) {
         if (ColType.MYSQL_JSON == ef.getColumnType()) {
-            return new MysqlJsonAdaptor();
+            ValueAdaptor adaptor = ef.getAdaptor();
+            if (adaptor instanceof MysqlJsonAdaptor) {
+                return adaptor;
+            } else {
+                return new MysqlJsonAdaptor();
+            }
         } else {
             return super.getAdaptor(ef);
         }

--- a/src/org/nutz/dao/impl/jdbc/mysql/MysqlJsonAdaptor.java
+++ b/src/org/nutz/dao/impl/jdbc/mysql/MysqlJsonAdaptor.java
@@ -17,6 +17,8 @@ import org.nutz.json.JsonFormat;
  * 注意，必要的时候需要给 POJO 添加<b>带一个参数的静态工厂方法</b>或者<b>带一个参数的构造函数</b>，<br>
  * 显示的使用 java.sql.ResultSet 来创建该 POJO，不然会出现无法映射的错误。
  * <p/>
+ * 数据库中默认使用 {@code JsonFormat.tidy()} 格式来保存JSON类型字段的值。
+ * <p/>
  *
  * <pre>
  * public class Pet {
@@ -59,6 +61,16 @@ import org.nutz.json.JsonFormat;
  */
 public class MysqlJsonAdaptor implements ValueAdaptor {
 
+    private JsonFormat jsonFormat;
+
+    public MysqlJsonAdaptor() {
+        this.jsonFormat = JsonFormat.tidy();
+    }
+
+    public void setJsonFormat(JsonFormat jsonFormat) {
+        this.jsonFormat = jsonFormat;
+    }
+
     public Object get(ResultSet rs, String colName) throws SQLException {
         return rs.getObject(colName);
     }
@@ -67,7 +79,7 @@ public class MysqlJsonAdaptor implements ValueAdaptor {
         if (null == obj) {
             stat.setNull(index, Types.NULL);
         } else {
-            stat.setObject(index, Json.toJson(obj, JsonFormat.tidy()), Types.VARCHAR);
+            stat.setObject(index, Json.toJson(obj, jsonFormat), Types.VARCHAR);
         }
     }
 }

--- a/src/org/nutz/dao/impl/jdbc/mysql/MysqlJsonCompactAdaptor.java
+++ b/src/org/nutz/dao/impl/jdbc/mysql/MysqlJsonCompactAdaptor.java
@@ -1,0 +1,22 @@
+package org.nutz.dao.impl.jdbc.mysql;
+
+import org.nutz.json.JsonFormat;
+
+/**
+ * 数据库中使用 {@code JsonFormat.compact()} 格式来保存JSON类型字段的值。
+ * <p />
+ * 使用时 {@code ColDefine} 注解的 {@code adaptor} 属性显示声明为 {@code MysqlJsonCompactAdaptor.class}
+ * <p />
+ * <pre>
+ * {@code
+ * @ColDefine(customType = "json", type = ColType.MYSQL_JSON, adaptor = MysqlJsonCompactAdaptor.class)
+ * private Information info;
+ * }
+ * </pre>
+ */
+public class MysqlJsonCompactAdaptor extends MysqlJsonAdaptor {
+
+    public MysqlJsonCompactAdaptor() {
+        setJsonFormat(JsonFormat.compact());
+    }
+}

--- a/src/org/nutz/dao/impl/jdbc/mysql/MysqlJsonTidyAdaptor.java
+++ b/src/org/nutz/dao/impl/jdbc/mysql/MysqlJsonTidyAdaptor.java
@@ -1,0 +1,22 @@
+package org.nutz.dao.impl.jdbc.mysql;
+
+import org.nutz.json.JsonFormat;
+
+/**
+ * 数据库中使用 {@code JsonFormat.tidy()} 格式来保存JSON类型字段的值。
+ * <p />
+ * 使用时 {@code ColDefine} 注解的 {@code adaptor} 属性显示声明为 {@code MysqlJsonTidyAdaptor.class}
+ * <p />
+ * <pre>
+ * {@code
+ * @ColDefine(customType = "json", type = ColType.MYSQL_JSON, adaptor = MysqlJsonTidyAdaptor.class)
+ * private Information info;
+ * }
+ * </pre>
+ */
+public class MysqlJsonTidyAdaptor extends MysqlJsonAdaptor {
+
+    public MysqlJsonTidyAdaptor() {
+        setJsonFormat(JsonFormat.tidy());
+    }
+}

--- a/src/org/nutz/dao/impl/jdbc/psql/PsqlJdbcExpert.java
+++ b/src/org/nutz/dao/impl/jdbc/psql/PsqlJdbcExpert.java
@@ -169,7 +169,12 @@ public class PsqlJdbcExpert extends AbstractJdbcExpert {
         if (ef.getMirror().isOf(Blob.class)) {
             return new BlobValueAdaptor3(Jdbcs.getFilePool());
         } else if (ColType.PSQL_JSON == ef.getColumnType()) {
-            return new PsqlJsonAdaptor();
+            ValueAdaptor adaptor = ef.getAdaptor();
+            if (adaptor instanceof PsqlJsonAdaptor) {
+                return adaptor;
+            } else {
+                return new PsqlJsonAdaptor();
+            }
         } else if (ColType.PSQL_ARRAY == ef.getColumnType()) {
             return new PsqlArrayAdaptor(ef.getCustomDbType());
         } else {

--- a/src/org/nutz/dao/impl/jdbc/psql/PsqlJsonAdaptor.java
+++ b/src/org/nutz/dao/impl/jdbc/psql/PsqlJsonAdaptor.java
@@ -17,6 +17,9 @@ import org.nutz.json.JsonFormat;
  * 注意，必要的时候需要给 POJO 添加<b>带一个参数的静态工厂方法</b>或者<b>带一个参数的构造函数</b>，<br>
  * 显示的使用 java.sql.ResultSet 来创建该 POJO，不然会出现无法映射的错误。
  * <p/>
+ * 数据库中默认使用 {@code JsonFormat.tidy()} 格式来保存JSON类型字段的值。
+ * <p/>
+ *
  * <pre>
  * public class Pet {
  *
@@ -58,6 +61,16 @@ import org.nutz.json.JsonFormat;
  */
 public class PsqlJsonAdaptor implements ValueAdaptor {
 
+    private JsonFormat jsonFormat;
+
+    public PsqlJsonAdaptor() {
+        this.jsonFormat = JsonFormat.tidy();
+    }
+
+    public void setJsonFormat(JsonFormat jsonFormat) {
+        this.jsonFormat = jsonFormat;
+    }
+
     public Object get(ResultSet rs, String colName) throws SQLException {
         return rs.getObject(colName);
     }
@@ -66,7 +79,7 @@ public class PsqlJsonAdaptor implements ValueAdaptor {
         if (null == obj) {
             stat.setNull(index, Types.NULL);
         } else {
-            stat.setObject(index, Json.toJson(obj, JsonFormat.tidy()), Types.OTHER);
+            stat.setObject(index, Json.toJson(obj, jsonFormat), Types.OTHER);
         }
     }
 }

--- a/src/org/nutz/dao/impl/jdbc/psql/PsqlJsonCompactAdaptor.java
+++ b/src/org/nutz/dao/impl/jdbc/psql/PsqlJsonCompactAdaptor.java
@@ -1,0 +1,22 @@
+package org.nutz.dao.impl.jdbc.psql;
+
+import org.nutz.json.JsonFormat;
+
+/**
+ * 数据库中使用 {@code JsonFormat.compact()} 格式来保存JSON类型字段的值。
+ * <p />
+ * 使用时 {@code ColDefine} 注解的 {@code adaptor} 属性显示声明为 {@code PsqlJsonCompactAdaptor.class}
+ * <p />
+ * <pre>
+ * {@code
+ * @ColDefine(customType = "json", type = ColType.PSQL_JSON, adaptor = PsqlJsonCompactAdaptor.class)
+ * private Information info;
+ * }
+ * </pre>
+ */
+public class PsqlJsonCompactAdaptor extends PsqlJsonAdaptor {
+
+    public PsqlJsonCompactAdaptor() {
+        setJsonFormat(JsonFormat.compact());
+    }
+}

--- a/src/org/nutz/dao/impl/jdbc/psql/PsqlJsonTidyAdaptor.java
+++ b/src/org/nutz/dao/impl/jdbc/psql/PsqlJsonTidyAdaptor.java
@@ -1,0 +1,22 @@
+package org.nutz.dao.impl.jdbc.psql;
+
+import org.nutz.json.JsonFormat;
+
+/**
+ * 数据库中使用 {@code JsonFormat.tidy()} 格式来保存JSON类型字段的值。
+ * <p />
+ * 使用时 {@code ColDefine} 注解的 {@code adaptor} 属性显示声明为 {@code PsqlJsonTidyAdaptor.class}
+ * <p />
+ * <pre>
+ * {@code
+ * @ColDefine(customType = "json", type = ColType.PSQL_JSON, adaptor = PsqlJsonTidyAdaptor.class)
+ * private Information info;
+ * }
+ * </pre>
+ */
+public class PsqlJsonTidyAdaptor extends PsqlJsonAdaptor {
+
+    public PsqlJsonTidyAdaptor() {
+        setJsonFormat(JsonFormat.tidy());
+    }
+}

--- a/test/org/nutz/dao/test/normal/mysql/AllMysqlTest.java
+++ b/test/org/nutz/dao/test/normal/mysql/AllMysqlTest.java
@@ -4,5 +4,5 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
-@Suite.SuiteClasses({MysqlJsonTest.class})
+@Suite.SuiteClasses({MysqlJsonTest.class, MysqlJsonAdaptorTest.class})
 public class AllMysqlTest {}

--- a/test/org/nutz/dao/test/normal/mysql/MysqlJsonAdaptorTest.java
+++ b/test/org/nutz/dao/test/normal/mysql/MysqlJsonAdaptorTest.java
@@ -1,0 +1,48 @@
+package org.nutz.dao.test.normal.mysql;
+
+import static org.junit.Assert.assertEquals;
+
+import java.math.BigDecimal;
+
+import org.junit.Test;
+import org.nutz.dao.Cnd;
+import org.nutz.dao.test.DaoCase;
+import org.nutz.json.Json;
+import org.nutz.json.JsonFormat;
+
+public class MysqlJsonAdaptorTest extends DaoCase {
+
+    @Override
+    protected void before() {
+        if (!dao.meta().isMySql()) {
+            return;
+        }
+        dao.create(MysqlJsonAdaptorTestBean.class, true);
+    }
+
+    @Test
+    public void adapotor() {
+        if (!dao.meta().isMySql()) {
+            return;
+        }
+
+        MysqlJsonAdaptorTestBean testBean = new MysqlJsonAdaptorTestBean();
+        StudentResult result = new StudentResult();
+        result.setPhysics(new BigDecimal("100"));
+        testBean.setNoneAdaptor(result);
+        testBean.setJsonAdaptor(result);
+        testBean.setJsonCompactAdaptor(result);
+        testBean.setJsonTidyAdaptor(result);
+
+        int insertId = dao.insert(testBean).getId();
+
+        org.nutz.dao.entity.Record record = dao.fetch("t_mysql_json_adaptor_test_bean", Cnd.where("id","=",insertId));
+        // mysql 在保存 json 格式字段的时候会自动格式化该字段的值
+        // mariadb 的话就没问题
+        assertEquals(Json.toJson(result, JsonFormat.tidy()), record.getString("noneAdaptor"));
+        assertEquals(Json.toJson(result, JsonFormat.tidy()), record.getString("noneAdaptor"));
+        assertEquals(Json.toJson(result, JsonFormat.tidy()), record.getString("jsonAdaptor"));
+        assertEquals(Json.toJson(result, JsonFormat.compact()), record.getString("jsonCompactAdaptor"));
+        assertEquals(Json.toJson(result, JsonFormat.tidy()), record.getString("jsonTidyAdaptor"));
+    }
+}

--- a/test/org/nutz/dao/test/normal/mysql/MysqlJsonAdaptorTestBean.java
+++ b/test/org/nutz/dao/test/normal/mysql/MysqlJsonAdaptorTestBean.java
@@ -1,0 +1,68 @@
+package org.nutz.dao.test.normal.mysql;
+
+import org.nutz.dao.entity.annotation.ColDefine;
+import org.nutz.dao.entity.annotation.ColType;
+import org.nutz.dao.entity.annotation.Id;
+import org.nutz.dao.entity.annotation.Table;
+import org.nutz.dao.impl.jdbc.mysql.MysqlJsonAdaptor;
+import org.nutz.dao.impl.jdbc.mysql.MysqlJsonCompactAdaptor;
+import org.nutz.dao.impl.jdbc.mysql.MysqlJsonTidyAdaptor;
+
+@Table("t_mysql_json_adaptor_test_bean")
+public class MysqlJsonAdaptorTestBean {
+
+    @Id
+    private int id;
+
+    @ColDefine(customType = "json", type = ColType.MYSQL_JSON)
+    private StudentResult noneAdaptor;
+
+    @ColDefine(customType = "json", type = ColType.MYSQL_JSON, adaptor = MysqlJsonAdaptor.class)
+    private StudentResult jsonAdaptor;
+
+    @ColDefine(customType = "json", type = ColType.MYSQL_JSON, adaptor = MysqlJsonCompactAdaptor.class)
+    private StudentResult jsonCompactAdaptor;
+
+    @ColDefine(customType = "json", type = ColType.MYSQL_JSON, adaptor = MysqlJsonTidyAdaptor.class)
+    private StudentResult jsonTidyAdaptor;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public StudentResult getNoneAdaptor() {
+        return noneAdaptor;
+    }
+
+    public void setNoneAdaptor(StudentResult noneAdaptor) {
+        this.noneAdaptor = noneAdaptor;
+    }
+
+    public StudentResult getJsonAdaptor() {
+        return jsonAdaptor;
+    }
+
+    public void setJsonAdaptor(StudentResult jsonAdaptor) {
+        this.jsonAdaptor = jsonAdaptor;
+    }
+
+    public StudentResult getJsonCompactAdaptor() {
+        return jsonCompactAdaptor;
+    }
+
+    public void setJsonCompactAdaptor(StudentResult jsonCompactAdaptor) {
+        this.jsonCompactAdaptor = jsonCompactAdaptor;
+    }
+
+    public StudentResult getJsonTidyAdaptor() {
+        return jsonTidyAdaptor;
+    }
+
+    public void setJsonTidyAdaptor(StudentResult jsonTidyAdaptor) {
+        this.jsonTidyAdaptor = jsonTidyAdaptor;
+    }
+}

--- a/test/org/nutz/dao/test/normal/psql/AllPsqlTest.java
+++ b/test/org/nutz/dao/test/normal/psql/AllPsqlTest.java
@@ -4,5 +4,5 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
-@Suite.SuiteClasses({PsqlJsonTest.class, PsqlArrayTest.class})
+@Suite.SuiteClasses({PsqlJsonTest.class, PsqlArrayTest.class, PsqlJsonAdaptorTest.class})
 public class AllPsqlTest {}

--- a/test/org/nutz/dao/test/normal/psql/PsqlJsonAdaptorTest.java
+++ b/test/org/nutz/dao/test/normal/psql/PsqlJsonAdaptorTest.java
@@ -1,0 +1,47 @@
+package org.nutz.dao.test.normal.psql;
+
+import static org.junit.Assert.assertEquals;
+
+import java.math.BigDecimal;
+
+import org.junit.Test;
+import org.nutz.dao.Cnd;
+import org.nutz.dao.test.DaoCase;
+import org.nutz.json.Json;
+import org.nutz.json.JsonFormat;
+
+public class PsqlJsonAdaptorTest extends DaoCase {
+
+    @Override
+    protected void before() {
+        if (!dao.meta().isPostgresql()) {
+            return;
+        }
+        dao.create(PsqlJsonAdaptorTestBean.class, true);
+    }
+
+    @Test
+    public void adapotor() {
+        if (!dao.meta().isPostgresql()) {
+            return;
+        }
+
+        PsqlJsonAdaptorTestBean testBean = new PsqlJsonAdaptorTestBean();
+        org.nutz.dao.test.normal.psql.StudentResult result = new StudentResult();
+        result.setPhysics(new BigDecimal("100"));
+        testBean.setNoneAdaptor(result);
+        testBean.setJsonAdaptor(result);
+        testBean.setJsonCompactAdaptor(result);
+        testBean.setJsonTidyAdaptor(result);
+
+        int insertId = dao.insert(testBean).getId();
+
+        org.nutz.dao.entity.Record record = dao.fetch("t_psql_json_adaptor_test_bean", Cnd.where("id","=",insertId));
+        // 设置成 jsonb 格式的时候会自动格式化该字段的值
+        assertEquals(Json.toJson(result, JsonFormat.tidy()), record.getString("noneAdaptor"));
+        assertEquals(Json.toJson(result, JsonFormat.tidy()), record.getString("noneAdaptor"));
+        assertEquals(Json.toJson(result, JsonFormat.tidy()), record.getString("jsonAdaptor"));
+        assertEquals(Json.toJson(result, JsonFormat.compact()), record.getString("jsonCompactAdaptor"));
+        assertEquals(Json.toJson(result, JsonFormat.tidy()), record.getString("jsonTidyAdaptor"));
+    }
+}

--- a/test/org/nutz/dao/test/normal/psql/PsqlJsonAdaptorTestBean.java
+++ b/test/org/nutz/dao/test/normal/psql/PsqlJsonAdaptorTestBean.java
@@ -1,0 +1,68 @@
+package org.nutz.dao.test.normal.psql;
+
+import org.nutz.dao.entity.annotation.ColDefine;
+import org.nutz.dao.entity.annotation.ColType;
+import org.nutz.dao.entity.annotation.Id;
+import org.nutz.dao.entity.annotation.Table;
+import org.nutz.dao.impl.jdbc.psql.PsqlJsonAdaptor;
+import org.nutz.dao.impl.jdbc.psql.PsqlJsonCompactAdaptor;
+import org.nutz.dao.impl.jdbc.psql.PsqlJsonTidyAdaptor;
+
+@Table("t_psql_json_adaptor_test_bean")
+public class PsqlJsonAdaptorTestBean {
+
+    @Id
+    private int id;
+
+    @ColDefine(customType = "jsonb", type = ColType.PSQL_JSON)
+    private StudentResult noneAdaptor;
+
+    @ColDefine(customType = "json", type = ColType.PSQL_JSON, adaptor = PsqlJsonAdaptor.class)
+    private StudentResult jsonAdaptor;
+
+    @ColDefine(customType = "json", type = ColType.PSQL_JSON, adaptor = PsqlJsonCompactAdaptor.class)
+    private StudentResult jsonCompactAdaptor;
+
+    @ColDefine(customType = "json", type = ColType.PSQL_JSON, adaptor = PsqlJsonTidyAdaptor.class)
+    private StudentResult jsonTidyAdaptor;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public org.nutz.dao.test.normal.psql.StudentResult getNoneAdaptor() {
+        return noneAdaptor;
+    }
+
+    public void setNoneAdaptor(StudentResult noneAdaptor) {
+        this.noneAdaptor = noneAdaptor;
+    }
+
+    public StudentResult getJsonAdaptor() {
+        return jsonAdaptor;
+    }
+
+    public void setJsonAdaptor(StudentResult jsonAdaptor) {
+        this.jsonAdaptor = jsonAdaptor;
+    }
+
+    public StudentResult getJsonCompactAdaptor() {
+        return jsonCompactAdaptor;
+    }
+
+    public void setJsonCompactAdaptor(StudentResult jsonCompactAdaptor) {
+        this.jsonCompactAdaptor = jsonCompactAdaptor;
+    }
+
+    public StudentResult getJsonTidyAdaptor() {
+        return jsonTidyAdaptor;
+    }
+
+    public void setJsonTidyAdaptor(StudentResult jsonTidyAdaptor) {
+        this.jsonTidyAdaptor = jsonTidyAdaptor;
+    }
+}

--- a/test/tmpl.nutz-test.properties
+++ b/test/tmpl.nutz-test.properties
@@ -1,6 +1,6 @@
-driver=com.mysql.jdbc.Driver
+driver=com.mysql.cj.jdbc.Driver
 #driver=org.mariadb.jdbc.Driver
-url=jdbc:mysql://127.0.0.1/nutztest?zeroDateTimeBehavior=convertToNull&serverTimezone=GMT%2b8
+url=jdbc:mysql://127.0.0.1:3306/nutztest?zeroDateTimeBehavior=convertToNull&serverTimezone=GMT%2b8
 username=root
 password=root
 
@@ -21,7 +21,7 @@ password=root
 #url=jdbc:h2:mem:
 
 #driver=org.postgresql.Driver
-#url=jdbc:postgresql://127.0.0.1:5433/nutztest
+#url=jdbc:postgresql://127.0.0.1:5432/nutztest
 #username=postgres
 #password=root
 #validationQuery=select 1


### PR DESCRIPTION
默认的是使用 `JsonFormat.tidy()` 格式来进行数据保存，添加上可使用 `JsonFormat.compact()` 格式的方式来进行保存。